### PR TITLE
Moved default packet size to central class to be adjustable.

### DIFF
--- a/doc/documentation/source/tutorials/discover_features.rst
+++ b/doc/documentation/source/tutorials/discover_features.rst
@@ -604,6 +604,28 @@ In the server part, we quickly get a segmentation fault, due to a bug in the par
   0x08048bc0 in api_encrypt (in=0x45ce7e32 <Address 0x45ce7e32 out of bounds>, len=3561020133, out=0xb4f2eded <Address 0xb4f2eded out of bounds>) at amo_api.c:80
    80	      tmpData[i] = (in[i] ^ key) % 0xff;
 
+Troubleshooting
+^^^^^^^^^^^^^^^
+
+When your network traces contain big packets you will stumble upon the following exception::
+
+  from netzob.all import *
+  messages = PCAPImporter.readFile('trace_with_large_packets.pcap').values()
+  symbols = Format.clusterByAlignment(messages)
+
+  ValueError                                Traceback (most recent call last)
+  ----> 1 symbols = Format.clusterByAlignment(messages)
+  [...]
+  ValueError: Maximum size supported for a variable is 1024 bits multiplyed by unit size (default 8).
+
+Netzob gives you the opportunity to generate packet payloads when modeling your own protocol. When one doesn't state an upper size limit for a packet, then Netzob's internal limit is used. This is set to 1024 bytes by default.
+Sometimes this limit prevents you from working with network traces containing bigger packets. You can raise the maximal packet size globally::
+
+  NetzobConfig.setMaxDataSize(4096)
+  symbols = Format.clusterByAlignment(messages)
+
+
+
 That's all folks for this introduction tutorial. You can get the entire `source code <https://dev.netzob.org/attachments/download/183/inference_target_src_v1.py>`_ of the script used to infer and play with the protocol:
 
 We invite you to read the API documentation or talk with us on IRC (#netzob on Freenode) if you have any question.

--- a/src/netzob/Common/Models/Types/AbstractType.py
+++ b/src/netzob/Common/Models/Types/AbstractType.py
@@ -47,6 +47,7 @@ import random
 #+---------------------------------------------------------------------------+
 from netzob.Common.Utils.Decorators import typeCheck, NetzobLogger
 from netzob.Common.Models.Vocabulary.Domain.Variables.SVAS import SVAS
+from netzob.NetzobConfig import NetzobConfig
 
 @NetzobLogger
 class AbstractType(object):
@@ -78,11 +79,6 @@ class AbstractType(object):
     UNITSIZE_16 = '16'
     UNITSIZE_32 = '32'
     UNITSIZE_64 = '64'
-
-    # This value will be used if generate() method is called
-    # without any upper size limit
-    # 8192 is completly arbitrary and equals 1k of data (1024 bytes)
-    MAXIMUM_GENERATED_DATA_SIZE = 8192
 
     @staticmethod
     def supportedTypes():
@@ -275,7 +271,7 @@ class AbstractType(object):
 
         minSize, maxSize = self.size
         if maxSize is None:
-            maxSize = AbstractType.MAXIMUM_GENERATED_DATA_SIZE
+            maxSize = NetzobConfig.getMaxDataSize() * 8
 
         generatedSize = random.randint(minSize, maxSize)
         randomContent = [random.randint(0, 1) for i in range(0, generatedSize)]
@@ -456,8 +452,9 @@ class AbstractType(object):
                 raise ValueError("Minimum size must be greater than 0")
             if maxSize is not None and maxSize < minSize:
                 raise ValueError("Maximum must be greater or equals to the minimum")
-            if maxSize is not None and maxSize > AbstractType.MAXIMUM_GENERATED_DATA_SIZE:
-                raise ValueError("Maximum size supported for a variable is {0}.".format(AbstractType.MAXIMUM_GENERATED_DATA_SIZE))
+            if maxSize is not None and maxSize > (NetzobConfig.getMaxDataSize() * 8):
+                raise ValueError("Maximum size supported for a variable is {0}\
+ bits multiplyed by unit size (default 8).".format(NetzobConfig.getMaxDataSize()))
 
             self.__size = (minSize, maxSize)
         else:

--- a/src/netzob/NetzobConfig.py
+++ b/src/netzob/NetzobConfig.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #+---------------------------------------------------------------------------+
@@ -25,13 +24,44 @@
 #| @sponsors : Amossys, http://www.amossys.fr                                |
 #|             Supélec, http://www.rennes.supelec.fr/ren/rd/cidre/           |
 #+---------------------------------------------------------------------------+
+#+---------------------------------------------------------------------------+
+#| File contributors :                                                       |
+#|       - Sergej Schmidt <sergej.schmidt (a) uni-ulm.de>                    |
+#+---------------------------------------------------------------------------+)
 
-# List subpackages to import with the current one
-# see docs.python.org/2/tutorial/modules.html
 
-import release
+#+---------------------------------------------------------------------------+
+#| Class containing global configurations of Netzob.
+#+---------------------------------------------------------------------------+
+class NetzobConfig(object):
+    """
+    Contains global configuration and tuning options of Netzob.
+    """
+    # This value will be used if generate() method is called
+    # without any upper size limit
+    # 8192 is completly arbitrary and equals 1k of data (1024 bytes)
+    max_gen_size = 8192
 
-from NetzobConfig import NetzobConfig
-from netzob.Common.all import *
-from netzob.Inference.all import *
-from netzob.Import.all import *
+    @staticmethod
+    def setMaxDataSize(size):
+        """
+        Set the maximal data size of a packet in bytes. The value is limited
+        so the during generation of packets the memory usage doesn't explode.
+        You can increase the maximal value by calling setMaxDataSize() gloabally.
+
+        >> from netzob.all import *
+        >> NetzobConfig.setMaxDataSize(4048)
+        """
+        if not isinstance(size, int):
+            raise ValueError("Size must be an integer value!")
+        if size <= 0 or (size & (size - 1) != 0):
+            raise ValueError("Value of size must be power of two. E.g. 2048.")
+        NetzobConfig.max_gen_size = size * 8
+
+    @staticmethod
+    def getMaxDataSize():
+        """
+        Returns the current configuration of the maximal value of a packet size
+        in bytes.
+        """
+        return NetzobConfig.max_gen_size / 8


### PR DESCRIPTION
Reworked PR: 
This enables users to set the upper size limit of packets globally. 