### PR TITLE
Fix TypeEncodingFunction bug which causes the endianness to be ignored.

### DIFF
--- a/src/netzob/Common/Models/Vocabulary/Functions/EncodingFunctions/TypeEncodingFunction.py
+++ b/src/netzob/Common/Models/Vocabulary/Functions/EncodingFunctions/TypeEncodingFunction.py
@@ -95,7 +95,7 @@ class TypeEncodingFunction(EncodingFunction):
 
     def encode(self, data):
         self._logger.debug(data)
-        return TypeConverter.convert(data, BitArray, self.type, src_unitSize=self.unitSize, src_endianness=self.endianness, src_sign=self.sign)
+        return TypeConverter.convert(data, BitArray, self.type, dst_unitSize=self.unitSize, dst_endianness=self.endianness, dst_sign=self.sign)
 
     def priority(self):
         """Returns the priority of the current encoding filter."""


### PR DESCRIPTION
This is a pull request for issue #34.  Please see the issue description for more details.
