### PR TITLE
Log verbosity can be set via environment variable 'NETZOB_LOG_LEVEL'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,8 +92,9 @@ Or if you prefer a more developer-friendly install::
   $ python3 setup.py develop --user
 
   
-Docker container:
-^^^^^^^^^^^^^^^^^
+Docker container
+^^^^^^^^^^^^^^^^
+
 A docker build is offered from the docker registry repository. You can download 
 it from command line with the following command:: 
 
@@ -110,24 +111,38 @@ Once installed, running Netzob is as simple as executing the provided script::
 This script is in Python's path if you've installed Netzob, otherwise
 (in developer mode), it's located in the top distribution directory.
 
+Docker container
+^^^^^^^^^^^^^^^^
+
 If you used the docker container, the following command will allow you to start 
 netzob with your current directory attached to ``/data`` into the container::
 
   $ docker run --rm -it -v $(pwd):/data netzob/netzob
 
-
 Miscellaneous
 -------------
 
-Configuration requirements for Network and PCAP input::
+Configuration of Log Level
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-*Note: Capturing data from network interfaces often requires admin privileges. Before we provide a cleaner and secure way (see issue 425 on the bugtracker for updated information - https://dev.netzob.org/issues/425), a possible HACK is to provide additionnal capabilities to the python binary.* ::
+Environment variable ```NETZOB_LOG_VERBOSITY``` can be use to set the logging level. The numeric values of logging levels are given in the Python Documentation of the `Logging Module <https://docs.python.org/3.5/library/logging.html#levels>`_. For example, the following command starts netzob in *DEBUG* mode::
 
-  $ sudo setcap cap_net_raw=ep /usr/bin/python3.XX
+  $ NETZOB_LOG_LEVEL=10 ./netzob
 
-Configuration requirements for IPC input on Ubuntu::
+Configuration requirements for Network and PCAP input
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  $ sudo bash -c "echo 0 > /proc/sys/kernel/yama/ptrace_scope"
+Capturing data from network interfaces often requires admin privileges. 
+Before we provide a cleaner and secure way (see issue 425 on the bugtracker for updated information - https://dev.netzob.org/issues/425), a possible *HACK* is to provide additional capabilities to the python binary::
+
+$ sudo setcap cap_net_raw=ep /usr/bin/python3.XX
+
+Configuration requirements for IPC input on Ubuntu
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following command must be triggered before collecting IPC exchanges with Netzob on Ubuntu (see https://www.kernel.org/doc/Documentation/security/Yama.txt)::
+
+$ sudo bash -c "echo 0 > /proc/sys/kernel/yama/ptrace_scope"
 
 Documentation
 =============

--- a/netzob
+++ b/netzob
@@ -36,8 +36,6 @@
 #| Standard library imports
 #+---------------------------------------------------------------------------+
 import sys
-import logging
-logging.basicConfig(level=logging.DEBUG)
 import os
 
 if sys.version_info[0] < 3:

--- a/netzob
+++ b/netzob
@@ -48,7 +48,9 @@ if sys.version_info[0] < 3:
 sys.path.insert(0, 'src/')
 from netzob.Common.CommandLine import CommandLine
 from netzob import release
+from netzob.Common.Utils.Decorators import NetzobLogger
 
+@NetzobLogger
 def main():
     """Main function of the Netzob script."""
 
@@ -61,7 +63,7 @@ def main():
     # Starting the dependency checker
     from netzob.Common.DepCheck import DepCheck
     if not DepCheck.checkRequiredDependency():
-        logging.fatal("Some required dependency are not available and prevent netzob from starting.")
+        main._logger.fatal("Some required dependency are not available and prevent netzob from starting.")
         sys.exit()
 
     # Insert in the path the directory where _libNeedleman.pyd is

--- a/src/netzob/Common/Utils/Decorators.py
+++ b/src/netzob/Common/Utils/Decorators.py
@@ -35,6 +35,7 @@
 #| Standard library imports                                                  |
 #+---------------------------------------------------------------------------+
 import logging
+import os
 
 #+---------------------------------------------------------------------------+
 #| Related third party imports                                               |
@@ -112,8 +113,11 @@ def NetzobLogger(klass):
             break
     if not found:
         klass._logger = logging.getLogger(klass.__name__)
+        try:
+            klass._logger.setLevel(int(os.environ['NETZOB_LOG_LEVEL']))
+        except:
+            pass
         handler = ColourStreamHandler() if has_colour else logging.StreamHandler()
-        handler.setLevel(logging.DEBUG)
         fmt = '%(relativeCreated)d: [%(levelname)s] %(module)s:%(funcName)s: %(message)s'
         handler.setFormatter(logging.Formatter(fmt))
         klass._logger.addHandler(handler)


### PR DESCRIPTION
One can change the default log verbosity (set to WARNING) by means of the NETZOB_LOG_LEVEL environment variable.
This variable accepts an integer as the logging module defines it:
- DEBUG = 10
- INFO  = 20
- WARN  = 30
- ERROR = 40
- FATAL = 50

For example, the following snippet can be use to set to DEBUG the log level of netzob in your python scripts

```
import logging
import os
os.environ['NETZOB_LOG_LEVEL'] = str(logging.DEBUG)

from netzob.all import *
```