### PR TITLE
fix(python3): use ValuesView as the type of SymbolList

### DIFF
--- a/netzob/src/netzob/Inference/Grammar/AutomataFactories/ChainedStatesAutomataFactory.py
+++ b/netzob/src/netzob/Inference/Grammar/AutomataFactories/ChainedStatesAutomataFactory.py
@@ -28,6 +28,7 @@
 #+----------------------------------------------
 #| Standard library imports
 #+----------------------------------------------
+from collections.abc import ValuesView
 
 #+----------------------------------------------
 #| Related third party imports
@@ -46,7 +47,7 @@ from netzob.Model.Grammar.Transitions.CloseChannelTransition import CloseChannel
 @NetzobLogger
 class ChainedStatesAutomataFactory(object):
     @staticmethod
-    @typeCheck(list, list)
+    @typeCheck(list, ValuesView)
     def generate(abstractSession, symbolList):
         """Generate an automata that contains as many states and
         transitions as the number of request-response couples in the

--- a/netzob/src/netzob/Inference/Grammar/AutomataFactories/OneStateAutomataFactory.py
+++ b/netzob/src/netzob/Inference/Grammar/AutomataFactories/OneStateAutomataFactory.py
@@ -28,6 +28,7 @@
 #+----------------------------------------------
 #| Standard library imports
 #+----------------------------------------------
+from collections.abc import ValuesView
 
 #+----------------------------------------------
 #| Related third party imports
@@ -46,7 +47,7 @@ from netzob.Model.Grammar.Transitions.CloseChannelTransition import CloseChannel
 @NetzobLogger
 class OneStateAutomataFactory(object):
     @staticmethod
-    @typeCheck(list, list)
+    @typeCheck(list, ValuesView)
     def generate(abstractSession, symbolList):
         """Generate an automata that, according to an abstract
         session, contains a main state where each request-response

--- a/netzob/src/netzob/Inference/Grammar/AutomataFactories/PTAAutomataFactory.py
+++ b/netzob/src/netzob/Inference/Grammar/AutomataFactories/PTAAutomataFactory.py
@@ -28,6 +28,7 @@
 #+----------------------------------------------
 #| Standard library imports
 #+----------------------------------------------
+from collections.abc import ValuesView
 
 #+----------------------------------------------
 #| Related third party imports
@@ -47,7 +48,7 @@ from netzob.Model.Grammar.Transitions.AbstractTransition import AbstractTransiti
 @NetzobLogger
 class PTAAutomataFactory(object):
     @staticmethod
-    @typeCheck(list, list)
+    @typeCheck(list, ValuesView)
     def generate(abstractSessions, symbolList):
         """Generate an automata by merging different abstract sessions
         in a Prefix Tree Acceptor (PTA).

--- a/netzob/src/netzob/Model/Vocabulary/Session.py
+++ b/netzob/src/netzob/Model/Vocabulary/Session.py
@@ -29,6 +29,7 @@
 #| Standard library imports
 #+---------------------------------------------------------------------------+
 import uuid
+from collections.abc import ValuesView
 
 #+---------------------------------------------------------------------------+
 #| Related third party imports
@@ -287,7 +288,7 @@ class Session(object):
         else:
             return False
 
-    @typeCheck(list)
+    @typeCheck(ValuesView)
     def abstract(self, symbolList):
         """This method abstract each message of the current session
         into symbols according to a list of symbols given as


### PR DESCRIPTION
Changed files:
1. netzob/src/netzob/Inference/Grammar/AutomataFactories/ChainedStatesAutomataFactory.py
2. netzob/src/netzob/Inference/Grammar/AutomataFactories/OneStateAutomataFactory.py
3. netzob/src/netzob/Inference/Grammar/AutomataFactories/PTAAutomataFactory.py
4. netzob/src/netzob/Model/Vocabulary/Session.py

One file is not committed since it will be refactored in the next days.
1. netzob/src/netzob/Model/Grammar/Automata.py

This file should be updated according follows.
![image](https://cloud.githubusercontent.com/assets/1409883/24318793/6cc1030c-1146-11e7-925b-ca40daa7c188.png)

The updated src (with the uncommitted modifications) has been tested with the tutorial source code.