### PR TITLE
fix(python3): convert ValuesView to list for symbols.value() in tutorial

### DIFF
--- a/netzob/doc/documentation/source/tutorials/discover_features.rst
+++ b/netzob/doc/documentation/source/tutorials/discover_features.rst
@@ -313,10 +313,10 @@ We will generate a basic automaton that illustrates the sequence of commands and
     session = Session(messages_session1)
 
     # Abstract this session according to the inferred symbols
-    abstractSession = session.abstract(symbols.values())
+    abstractSession = session.abstract(list(symbols.values()))
 
     # Generate an automata according to the observed sequence of messages/symbols
-    automata = Automata.generateChainedStatesAutomata(abstractSession, symbols.values())
+    automata = Automata.generateChainedStatesAutomata(abstractSession, list(symbols.values()))
 
     # Print the dot representation of the automata
     dotcode = automata.generateDotCode()
@@ -362,10 +362,10 @@ This time, instead of converting a PCAP into a sequence of states for each messa
     session = Session(messages_session1)
 
     # Abstract this session according to the inferred symbols
-    abstractSession = session.abstract(symbols.values())
+    abstractSession = session.abstract(list(symbols.values()))
 
     # Generate an automata according to the observed sequence of messages/symbols
-    automata = Automata.generateOneStateAutomata(abstractSession, symbols.values())
+    automata = Automata.generateOneStateAutomata(abstractSession, list(symbols.values()))
 
     # Print the dot representation of the automata
     dotcode = automata.generateDotCode()
@@ -407,11 +407,11 @@ Finally, we convert multiple sequences of messages taken form different PCAP fil
     session3 = Session(messages_session3)
 
     # Abstract this session according to the inferred symbols
-    abstractSession1 = session1.abstract(symbols.values())
-    abstractSession3 = session3.abstract(symbols.values())
+    abstractSession1 = session1.abstract(list(symbols.values()))
+    abstractSession3 = session3.abstract(list(symbols.values()))
 
     # Generate an automata according to the observed sequence of messages/symbols
-    automata = Automata.generatePTAAutomata([abstractSession1, abstractSession3], symbols.values())
+    automata = Automata.generatePTAAutomata([abstractSession1, abstractSession3], list(symbols.values()))
 
     # Print the dot representation of the automata
     dotcode = automata.generateDotCode()
@@ -472,7 +472,7 @@ Then, we create a UDP client that will communicate with the server (on 127.0.0.1
 
     # Create a UDP client instance
     channelOut = UDPClient(remoteIP="127.0.0.1", remotePort=4242)
-    abstractionLayerOut = AbstractionLayer(channelOut, symbols.values())
+    abstractionLayerOut = AbstractionLayer(channelOut, list(symbols.values()))
     abstractionLayerOut.openChannel()
 
     # Visit the automata for n iteration


### PR DESCRIPTION
The type of symbols.values() becomes "collections.abc.ValuesView" in Python3, but the functions "session.abstract", "Automata.generate...Automata", and "AbstractionLayer" requires list (which is correct in python2). Therefore, I add the type conversions in the tutorial.

I have a previous pull request that changes the type from list to ValuesView, and I have closed it. Now, I think it is better to let the user do the conversion. It will be a better API this way.

The following shows that the type is changed in python 3.4.

In Python 2.7, the values function of "OrderedDict" is defined as follows, which is a list.
![image](https://cloud.githubusercontent.com/assets/1409883/24319333/e2958168-1153-11e7-901f-c493ab77679d.png)

However, in Python 3.4, it is defined as
![image](https://cloud.githubusercontent.com/assets/1409883/24319338/f9fb35b4-1153-11e7-8929-bd9e6664670b.png)
![image](https://cloud.githubusercontent.com/assets/1409883/24319339/fe07a8e0-1153-11e7-873e-3ea913ccab05.png)
![image](https://cloud.githubusercontent.com/assets/1409883/24319342/03e52350-1154-11e7-8bb1-455f1c2a41cd.png)

The updated src (with the uncommitted modifications) has been tested with the tutorial source code.