### PR TITLE
fix(NEWS): should be 2017, but not 2016

### DIFF
--- a/netzob/NEWS.rst
+++ b/netzob/NEWS.rst
@@ -1,7 +1,7 @@
 NEWS
 ====
 
-v1.0.2 -- 2016-04-30
+v1.0.2 -- 2017-04-30
 --------------------
 
 :Version name: StompingFrilledShark


### PR DESCRIPTION
The time in NEWS is not correct.