### PR TITLE
Fixed check for VLAN-tag Commented out missing ARP-Decoder

### DIFF
--- a/netzob/src/netzob/Import/PCAPImporter/ImpactDecoder.py
+++ b/netzob/src/netzob/Import/PCAPImporter/ImpactDecoder.py
@@ -65,9 +65,9 @@ class EthDecoder(Decoder):
         if e.get_ether_type() == ImpactPacket.IP.ethertype:
             self.ip_decoder = IPDecoder()
             packet = self.ip_decoder.decode(aBuffer[off:])
-        elif e.get_ether_type() == ImpactPacket.ARP.ethertype:
-            self.arp_decoder = ARPDecoder()
-            packet = self.arp_decoder.decode(aBuffer[off:])
+        # elif e.get_ether_type() == ImpactPacket.ARP.ethertype:
+        #     self.arp_decoder = ARPDecoder()
+        #     packet = self.arp_decoder.decode(aBuffer[off:])
         else:
             self.data_decoder = DataDecoder()
             packet = self.data_decoder.decode(aBuffer[off:])

--- a/netzob/src/netzob/Import/PCAPImporter/ImpactPacket.py
+++ b/netzob/src/netzob/Import/PCAPImporter/ImpactPacket.py
@@ -614,7 +614,7 @@ class Ethernet(Header):
     def load_header(self, aBuffer):
         self.tag_cnt = 0
         while aBuffer[12 + 4 * self.tag_cnt:14 + 4 * self.tag_cnt] in (
-                '\x81\x00', '\x88\xa8', '\x91\x00'):
+                b'\x81\x00', b'\x88\xa8', b'\x91\x00'):
             self.tag_cnt += 1
 
         hdr_len = self.get_header_size()


### PR DESCRIPTION
PCAPs with VLAN-tagged Ethernet frames failed to import, since a comparison of the tag field contents erroneously returned false. Problem was a string-typing mismatch. Fixed by the commit.

Moreover contains a workaround/quickfix for #107 to get the code into a working state for PCAPs containing Ethernet frames.