### PR TITLE
Respect endianness in size fields

### DIFF
--- a/netzob/src/netzob/Model/Vocabulary/Domain/Variables/Leafs/Size.py
+++ b/netzob/src/netzob/Model/Vocabulary/Domain/Variables/Leafs/Size.py
@@ -333,7 +333,9 @@ class Size(AbstractRelationVariableLeaf):
                                          src_unitSize=self.dataType.unitSize,
                                          dst_unitSize=self.dataType.unitSize,
                                          src_sign=self.dataType.sign,
-                                         dst_sign=self.dataType.sign)
+                                         dst_sign=self.dataType.sign,
+                                         src_endianness=self.dataType.endianness,
+                                         dst_endianness=self.dataType.endianness)
         b = TypeConverter.convert(size_raw, Raw, BitArray)
 
         # add heading '0'


### PR DESCRIPTION
Allow size fields with little endian:

```python
from netzob.all import *

msg = [RawMessage(b"\x07\x00;netzob")]

payloadField = Field(Raw(nbBytes=(0, 65535)), name="payload")
sizeField = Field(Size([payloadField], dataType=Integer(unitSize=AbstractType.UNITSIZE_16, endianness=AbstractType.ENDIAN_LITTLE)), name="pkgSize")

s = Symbol(messages=msg, fields=[sizeField, payloadField])
print(s)
```