### PR TITLE
Type conversion consistency

### DIFF
--- a/netzob/src/netzob/Inference/Vocabulary/CorrelationFinder.py
+++ b/netzob/src/netzob/Inference/Vocabulary/CorrelationFinder.py
@@ -235,6 +235,13 @@ class CorrelationFinder(object):
         result = []
         for data in cellsData:
             if len(data) > 0:
+                # Integer only may be 1, 2, 4, or 8 bytes long, so for conversion
+                # we need to add 0 padding at the front of the raw numbers
+                if len(data) == 3:
+                    data = b'\x00' + data
+                elif len(data) in (5,6,7):
+                    padding_length = 8 - len(data)
+                    data = padding_length *  b'\x00' + data
                 result.append(TypeConverter.convert(
                     data[:8], Raw, Integer))  # We take only the first 8 octets
             else:

--- a/netzob/src/netzob/Inference/Vocabulary/RelationFinder.py
+++ b/netzob/src/netzob/Inference/Vocabulary/RelationFinder.py
@@ -319,7 +319,16 @@ class RelationFinder(object):
                 y = len(y)
         else:
             if len(y) > 0:
-                y = TypeConverter.convert(y[:8], Raw, Integer)
+                # Integer only may be 1, 2, 4, or 8 bytes long, so for conversion
+                # we need to add 0 padding at the front of the raw numbers
+                if len(y) == 3:
+                    padded_y = b'\x00' + y
+                elif len(y) in (5,6,7):
+                    padding_length = 8 - len(y)
+                    padded_y = padding_length *  b'\x00' + y
+                else:
+                    padded_y = y
+                y = TypeConverter.convert(padded_y[:8], Raw, Integer)
             else:
                 y = 0
 

--- a/netzob/src/netzob/Model/Vocabulary/Types/ASCII.py
+++ b/netzob/src/netzob/Model/Vocabulary/Types/ASCII.py
@@ -383,6 +383,7 @@ class ASCII(AbstractType):
             if ordElt >= 0x20 and ordElt <= 0x7e:  # means between ' ' and '~'
                 res += chr(ordElt)
             else:
-                res += "."
+#                res += "."
+                raise ValueError('bytevalue {0}, is not ASCII encodable'.format(hex(ordElt)))
 
         return res

--- a/netzob/src/netzob/Model/Vocabulary/Types/ASCII.py
+++ b/netzob/src/netzob/Model/Vocabulary/Types/ASCII.py
@@ -383,7 +383,6 @@ class ASCII(AbstractType):
             if ordElt >= 0x20 and ordElt <= 0x7e:  # means between ' ' and '~'
                 res += chr(ordElt)
             else:
-#                res += "."
-                raise ValueError('bytevalue {0}, is not ASCII encodable'.format(hex(ordElt)))
+                res += "."
 
         return res

--- a/netzob/src/netzob/Model/Vocabulary/Types/AbstractType.py
+++ b/netzob/src/netzob/Model/Vocabulary/Types/AbstractType.py
@@ -158,7 +158,7 @@ class AbstractType(object, metaclass=abc.ABCMeta):
         :return: the default sign
         :rtype: str
         """
-        return AbstractType.SIGN_SIGNED
+        return AbstractType.SIGN_UNSIGNED
 
     def __init__(self,
                  typeName,

--- a/netzob/src/netzob/Model/Vocabulary/Types/IPv4.py
+++ b/netzob/src/netzob/Model/Vocabulary/Types/IPv4.py
@@ -321,7 +321,7 @@ class IPv4(AbstractType):
     def encode(data,
                unitSize=AbstractType.defaultUnitSize(),
                endianness=AbstractType.defaultEndianness(),
-               sign=AbstractType.defaultSign()):
+               sign=AbstractType.SIGN_UNSIGNED):
         """Encodes the specified data into an IPAddress object
 
         :param data: the data to encode into an IPAddress
@@ -337,11 +337,11 @@ class IPv4(AbstractType):
                 pass
         try:
 
-            structFormat = ">"
+            structFormat = "<"
             if endianness == AbstractType.ENDIAN_BIG:
                 structFormat = ">"
 
-            if not sign == AbstractType.SIGN_SIGNED:
+            if sign is AbstractType.SIGN_SIGNED:
                 structFormat += "bbbb"
             else:
                 structFormat += "BBBB"

--- a/netzob/src/netzob/Model/Vocabulary/Types/Integer.py
+++ b/netzob/src/netzob/Model/Vocabulary/Types/Integer.py
@@ -72,7 +72,7 @@ class Integer(AbstractType):
     >>> print(dec.size)
     (8, 8)
 
-    >>> dec = Integer(interval=(-120, 10))
+    >>> dec = Integer(interval=(-130, 10), sign=AbstractType.SIGN_SIGNED)
     >>> print(dec.size)
     (16, 16)
 
@@ -125,6 +125,13 @@ class Integer(AbstractType):
             value = None
 
         if interval is not None:
+            if sign==AbstractType.SIGN_UNSIGNED:
+                if isinstance(interval, int):
+                    if interval < 0: # value handling
+                        raise ValueError("Value with negative values needs signed type.")
+                elif len(interval) == 2: # interval handling
+                    if min(interval) < 0:
+                        raise ValueError("Interval with negative values needs signed type.")
             nbBits = int(
                 self._computeNbUnitSizeForInterval(interval, unitSize,
                                                    sign)) * int(unitSize)
@@ -215,7 +222,7 @@ class Integer(AbstractType):
         >>> print(Integer.decode(2000000000000000))
         Traceback (most recent call last):
         ...
-        struct.error: byte format requires -128 <= number <= 127
+        struct.error: ubyte format requires 0 <= number <= 255
 
         >>> print(Integer.decode(2000000000000000, unitSize=AbstractType.UNITSIZE_64))
         b'\\x00\\x07\\x1a\\xfdI\\x8d\\x00\\x00'
@@ -275,12 +282,14 @@ class Integer(AbstractType):
         >>> print(repr(Integer.encode(raw, unitSize=AbstractType.UNITSIZE_16, endianness=AbstractType.ENDIAN_LITTLE)))
         25
 
-        >>> print(Integer.encode(b'\\xcc\\xac\\x9c\\x0c\\x1c\\xacL\\x1c,\\xac', unitSize=AbstractType.UNITSIZE_8))
+        >>> print(Integer.encode(b'\\xcc\\xac\\x9c\\x0c\\x1c\\xacL\\x1c,\\xac', unitSize=AbstractType.UNITSIZE_8, sign=AbstractType.SIGN_SIGNED))
         -395865088909314208584756
 
+        # raw is interpreted as b'\xcc\xac\x00\x9c' by encode and
+        # as big endian with unit size 16 as (0x009c << 16) + 0xccac = 10276012
         >>> raw = b'\\xcc\\xac\\x9c'
         >>> print(Integer.encode(raw, unitSize=AbstractType.UNITSIZE_16, endianness=AbstractType.ENDIAN_BIG))
-        10210476
+        10276012
 
         >>> print(Integer.encode(raw, unitSize=AbstractType.UNITSIZE_32, endianness=AbstractType.ENDIAN_BIG))
         13413532

--- a/netzob/src/netzob/Model/Vocabulary/Types/Integer.py
+++ b/netzob/src/netzob/Model/Vocabulary/Types/Integer.py
@@ -101,6 +101,16 @@ class Integer(AbstractType):
             from netzob.Model.Vocabulary.Types.TypeConverter import TypeConverter
             from netzob.Model.Vocabulary.Types.BitArray import BitArray
             interval = value
+            if value <= math.pow(2,8)/2-1 and value >= -math.pow(2,8)/2:
+                unitSize=AbstractType.UNITSIZE_8
+            elif value <= math.pow(2,16)/2-1 and value >= -math.pow(2,16)/2: 
+                unitSize=AbstractType.UNITSIZE_16
+            elif value <= math.pow(2,32)/2-1 and value >= -math.pow(2,32)/2: 
+                unitSize=AbstractType.UNITSIZE_32
+            elif value <= math.pow(2,64)/2-1 and value >= -math.pow(2,64)/2: 
+                unitSize=AbstractType.UNITSIZE_64
+            else:
+                raise ValueError("value out of range")
             value = TypeConverter.convert(
                 value,
                 Integer,
@@ -147,12 +157,13 @@ class Integer(AbstractType):
         # the interval is a single value
         # bspec = ⌊log2(n)⌋ + 1 (+1 for signed)
         val = abs(val)
-        if sign == AbstractType.SIGN_UNSIGNED:
-            return math.floor(
-                (math.floor(math.log(val, 2)) + 1) / int(unitSize)) + 1
-        else:
-            return math.floor(
-                (math.floor(math.log(val, 2)) + 2) / int(unitSize)) + 1
+        if val != 0:
+            if sign == AbstractType.SIGN_UNSIGNED:
+                return math.floor(
+                    (math.floor(math.log(val, 2)) + 1) / int(unitSize)) + 1
+            else:
+                return math.floor(
+                    (math.floor(math.log(val, 2)) + 2) / int(unitSize)) + 1
 
     def canParse(self,
                  data,

--- a/netzob/src/netzob/Model/Vocabulary/Types/TypeConverter.py
+++ b/netzob/src/netzob/Model/Vocabulary/Types/TypeConverter.py
@@ -97,9 +97,9 @@ class TypeConverter(object):
         2816
         >>> TypeConverter.convert(11, Integer, Raw)
         b'\\x0b'
-        >>> TypeConverter.convert(b'\\xa0\\x0b', Raw, Integer)
+        >>> TypeConverter.convert(b'\\xa0\\x0b', Raw, Integer, dst_sign=AbstractType.SIGN_SIGNED)
         -24565
-        >>> TypeConverter.convert(-24565, Integer, Raw)
+        >>> TypeConverter.convert(-24565, Integer, Raw, src_sign=AbstractType.SIGN_SIGNED)
         b'\\xa0\\x0b'
         >>> TypeConverter.convert(0, Integer, Raw)
         b'\\x00'

--- a/netzob/src/netzob/Model/Vocabulary/Types/TypeConverter.py
+++ b/netzob/src/netzob/Model/Vocabulary/Types/TypeConverter.py
@@ -28,6 +28,7 @@
 # +---------------------------------------------------------------------------+
 # | Standard library imports                                                  |
 # +---------------------------------------------------------------------------+
+import math
 
 # +---------------------------------------------------------------------------+
 # | Related third party imports                                               |
@@ -38,6 +39,7 @@
 # +---------------------------------------------------------------------------+
 from netzob.Model.Vocabulary.Types.AbstractType import AbstractType
 from netzob.Model.Vocabulary.Types.Raw import Raw
+from netzob.Model.Vocabulary.Types.Integer import Integer
 
 
 class TypeConverter(object):
@@ -62,10 +64,10 @@ class TypeConverter(object):
     def convert(data,
                 sourceType,
                 destinationType,
-                src_unitSize=AbstractType.defaultUnitSize(),
+                src_unitSize=None,
                 src_endianness=AbstractType.defaultEndianness(),
                 src_sign=AbstractType.defaultSign(),
-                dst_unitSize=AbstractType.defaultUnitSize(),
+                dst_unitSize=None,
                 dst_endianness=AbstractType.defaultEndianness(),
                 dst_sign=AbstractType.defaultSign()):
         """Encode data provided as a sourceType to a destinationType.
@@ -88,20 +90,37 @@ class TypeConverter(object):
         35
         >>> print(TypeConverter.convert(decData, Integer, ASCII))
         #
+        
+        Conversion to and from Integer detects the output unitsize depending on the input:
+        
+        >>> TypeConverter.convert(b'\\x0b\\x00', Raw, Integer)
+        2816
+        >>> TypeConverter.convert(11, Integer, Raw)
+        b'\\x0b'
+        >>> TypeConverter.convert(b'\\xa0\\x0b', Raw, Integer)
+        -24565
+        >>> TypeConverter.convert(-24565, Integer, Raw)
+        b'\\xa0\\x0b'
+        >>> TypeConverter.convert(0, Integer, Raw)
+        b'\\x00'
+        >>> TypeConverter.convert(b'\\x00\\x00\\x00', Raw, Integer)
+        Traceback (most recent call last):
+        ...
+        TypeError: Unsupported UnitSize. Valid UnitSizes are 8,16,32 and 64 bits
 
         You can also play with the unitSize to convert multiple ascii in a single high value decimal
 
         >>> TypeConverter.convert("5", ASCII, Integer)
         53
         >>> print(TypeConverter.convert("zoby", ASCII, Integer))
-        2036494202
+        2054120057
         >>> print(TypeConverter.convert("zoby", ASCII, Integer, dst_unitSize=AbstractType.UNITSIZE_32))
         2054120057
 
         It also works for 'semantic' data like IPv4s
 
         >>> TypeConverter.convert("192.168.0.10", IPv4, Integer, dst_sign=AbstractType.SIGN_UNSIGNED)
-        167815360
+        3232235530
         >>> TypeConverter.convert("127.0.0.1", IPv4, BitArray)
         bitarray('01111111000000000000000000000001')
         >>> TypeConverter.convert(167815360, Integer, IPv4, src_unitSize=AbstractType.UNITSIZE_32, src_sign=AbstractType.SIGN_UNSIGNED)
@@ -127,6 +146,12 @@ class TypeConverter(object):
         :raise: TypeError if parameter not valid
 
         """
+	# Use defaultUnitSize for all types except Integer
+        if dst_unitSize is None and destinationType is not Integer: 
+            dst_unitSize = AbstractType.defaultUnitSize()
+        if src_unitSize is None and sourceType is not Integer:
+            src_unitSize = AbstractType.defaultUnitSize()
+
         # is the two formats supported ?
         if sourceType not in TypeConverter.supportedTypes():
             raise TypeError(
@@ -146,22 +171,66 @@ class TypeConverter(object):
                         dst_unitSize, dst_endianness, dst_sign)
         else:
             # Convert from source to raw
-            if sourceType is not Raw:
+            if sourceType is Integer and src_unitSize is None and src_sign is AbstractType.SIGN_SIGNED:
+                if data <= math.pow(2,8)/2-1 and data >= -math.pow(2,8)/2:
+                    src_unitSize=AbstractType.UNITSIZE_8
+                elif data <= math.pow(2,16)/2-1 and data >= -math.pow(2,16)/2: 
+                    src_unitSize=AbstractType.UNITSIZE_16
+                elif data <= math.pow(2,32)/2-1 and data >= -math.pow(2,32)/2: 
+                    src_unitSize=AbstractType.UNITSIZE_32
+                elif data <= math.pow(2,64)/2-1 and data >= -math.pow(2,64)/2: 
+                    src_unitSize=AbstractType.UNITSIZE_64
+                else:
+                    raise ValueError("Data Out-of-Range")
+            if sourceType is Integer and src_unitSize is None and src_sign is AbstractType.SIGN_UNSIGNED:
+                if data <= math.pow(2,8)-1 and data >= 0:
+                    src_unitSize=AbstractType.UNITSIZE_8
+                elif data <= math.pow(2,16)-1 and data >= 0:
+                    src_unitSize=AbstractType.UNITSIZE_16
+                elif data <= math.pow(2,32)-1 and data >= 0:
+                    src_unitSize=AbstractType.UNITSIZE_32
+                elif data <= math.pow(2,64)-1 and data >= 0:
+                    src_unitSize=AbstractType.UNITSIZE_64
+                else:
+                    raise ValueError("Data Out-of-Range")
                 binData = sourceType.decode(
-                    data,
-                    unitSize=src_unitSize,
-                    endianness=src_endianness,
-                    sign=src_sign)
+			data, 
+			unitSize=src_unitSize, 
+			endianness=src_endianness, 
+			sign=src_sign)
+            elif sourceType is not Raw:
+                binData = sourceType.decode(
+			data, 
+			unitSize=src_unitSize, 
+			endianness=src_endianness, 
+			sign=src_sign)
             else:
                 binData = data
 
             # Convert from raw to Destination
-            if destinationType is not Raw:
+            if destinationType is Integer and dst_unitSize is None:
+                nbUnits = len(binData)
+                if nbUnits == 8: 
+                    dst_unitSize = AbstractType.UNITSIZE_64
+                elif nbUnits == 4:
+                    dst_unitSize = AbstractType.UNITSIZE_32
+                elif nbUnits == 2:
+                    dst_unitSize = AbstractType.UNITSIZE_16
+                elif nbUnits == 1:
+                    dst_unitSize = AbstractType.UNITSIZE_8
+                else:
+                    raise TypeError("Unsupported UnitSize. Valid UnitSizes are 8,16,32 and 64 bits")
                 outputData = destinationType.encode(
-                    binData,
-                    unitSize=dst_unitSize,
-                    endianness=dst_endianness,
-                    sign=dst_sign)
+			binData, 
+			unitSize=dst_unitSize, 
+			endianness=dst_endianness, 
+			sign=dst_sign)
+            elif destinationType is not Raw:
+                outputData = destinationType.encode(
+			binData, 
+			unitSize=dst_unitSize, 
+			endianness=dst_endianness, 
+			sign=dst_sign)
             else:
                 outputData = binData
 


### PR DESCRIPTION
This fixes some inconsistencies in type conversion (```TypeConverter.convert()``` and adjacent classes).

* e.g. considering the value 3232235530 which is ```int("0xc0a8000a",0)``` should be:
    ```
    > hex(3232235530)
    '0xc0a8000a'
     ```  
    but ```TypeConverter.convert("192.168.0.10", IPv4, Integer, dst_sign=AbstractType.SIGN_UNSIGNED)``` resulted in: 167815360

* similarly ASCII -> Integer:
     e.g. the example from the doctest below resulted in 2036494202:
         print(TypeConverter.convert("zoby", ASCII, Integer))
     should have been 2054120057:
     ```
     > print('\x7a\x6f\x62\x79')
     zoby
     > int('0x7a6f6279',0)
     2054120057
     ```

* In addition, regard this excerpt from doctest in TypeConverter.py:  
    ```
    You can also play with the unitSize to convert multiple ascii in a single high value decimal
    ...
            >>> print(TypeConverter.convert("zoby", ASCII, Integer))
            2036494202
     ```
    I don't understand in which situation this might make sense. Instead it yields usage errors since a user might assume all input chars to be used in a conversion from ASCII and not silently disregarded. So I removed this kind of test and "feature".

* Change default sign to unsigned (much more common for network protocols).