### PR TITLE
Fix for Non deterministic results (Issue #30)

### DIFF
--- a/netzob/lib/argsFactories/factory.c
+++ b/netzob/lib/argsFactories/factory.c
@@ -159,14 +159,14 @@ void parseMessage(PyObject * item, t_message * message) {
   message->alignment = (unsigned char*) tmp_alignment;
 
   /**
-     message->mask will be allocated (no value in it yet) to contain at least ... ?
-  */
-  message->mask = calloc(strlen(tmp_alignment)+1,sizeof(unsigned char*));
-
-  /**
      message->len contains the size of tmp_alignment
   **/
   message->len = (unsigned int) PyLong_AsUnsignedLong(PyObject_GetAttrString(item, "length"));
+
+  /**
+     message->mask will be allocated (no value in it yet) to contain at least ... ?
+  */
+  message->mask = calloc(message->len,sizeof(unsigned char*));
 
   /**
      message->semanticTags contains the list of tags attached to each half-byte of the alignment

--- a/netzob/lib/argsFactories/factory.c
+++ b/netzob/lib/argsFactories/factory.c
@@ -166,12 +166,12 @@ void parseMessage(PyObject * item, t_message * message) {
   /**
      message->mask will be allocated (no value in it yet) to contain at least ... ?
   */
-  message->mask = calloc(message->len,sizeof(unsigned char*));
+  message->mask = calloc(message->len,sizeof(unsigned char));
 
   /**
      message->semanticTags contains the list of tags attached to each half-byte of the alignment
   */
-  message->semanticTags = calloc(message->len, sizeof(t_semanticTag *));
+  message->semanticTags = calloc(message->len, sizeof(t_semanticTag));
 
   // retrieve the list of tags
   PyObject* listOfSemanticTags = PyObject_GetAttrString(item, "semanticTags");


### PR DESCRIPTION
If one computes the alignment for one set of messages with CluserByAlignment Method multiple times the results differ.

This patch fixes this problem by changing 2 lines in the factory.c 