### PR TITLE
New Feature: XML-Handler

### DIFF
--- a/netzob/src/netzob/Export/XMLHandler/XMLHandler.py
+++ b/netzob/src/netzob/Export/XMLHandler/XMLHandler.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+
+#+---------------------------------------------------------------------------+
+#|          01001110 01100101 01110100 01111010 01101111 01100010            |
+#|                                                                           |
+#|               Netzob : Inferring communication protocols                  |
+#+---------------------------------------------------------------------------+
+#| Copyright (C) 2011-2017 Georges Bossert and Frédéric Guihéry              |
+#| This program is free software: you can redistribute it and/or modify      |
+#| it under the terms of the GNU General Public License as published by      |
+#| the Free Software Foundation, either version 3 of the License, or         |
+#| (at your option) any later version.                                       |
+#|                                                                           |
+#| This program is distributed in the hope that it will be useful,           |
+#| but WITHOUT ANY WARRANTY; without even the implied warranty of            |
+#| MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              |
+#| GNU General Public License for more details.                              |
+#|                                                                           |
+#| You should have received a copy of the GNU General Public License         |
+#| along with this program. If not, see <http://www.gnu.org/licenses/>.      |
+#+---------------------------------------------------------------------------+
+#| @url      : http://www.netzob.org                                         |
+#| @contact  : contact@netzob.org                                            |
+#| @sponsors : Amossys, http://www.amossys.fr                                |
+#|             Supélec, http://www.rennes.supelec.fr/ren/rd/cidre/           |
+#+---------------------------------------------------------------------------+
+
+#+---------------------------------------------------------------------------+
+#| Standard library imports
+#+---------------------------------------------------------------------------+
+from lxml.etree import ElementTree, DocumentInvalid
+from lxml import etree
+import uuid
+import os
+
+#+---------------------------------------------------------------------------+
+#| Related third party imports
+#+---------------------------------------------------------------------------+
+
+#+---------------------------------------------------------------------------+
+#| Local application imports
+#+---------------------------------------------------------------------------+
+from netzob.Common.Utils.Decorators import typeCheck, NetzobLogger
+from netzob.Model.Vocabulary.Symbol import Symbol
+
+
+
+SYMBOLS_NAMESPACE = "http://www.netzob.org/symbols"
+COMMON_NAMESPACE = "http://www.netzob.org/common"
+
+@NetzobLogger
+class XMLHandler(object):
+    unresolved_dict = dict()
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    @typeCheck(str, dict)
+    def add_to_unresolved_dict(name, unresolved):
+        if unresolved is not None and isinstance(unresolved, dict):
+            if name not in XMLHandler.unresolved_dict.keys():
+                XMLHandler.unresolved_dict[name] = dict()
+            for key, value in unresolved.items():
+                XMLHandler.unresolved_dict[name][key] = value
+
+    @staticmethod
+    @typeCheck(list, str)
+    def saveToXML(symbols, filepath):
+        '''
+        Saves the List of Symbols to XML
+        :return:
+        '''
+        # Register the namespace
+        etree.register_namespace('netzob', SYMBOLS_NAMESPACE)
+        etree.register_namespace('netzob-common', COMMON_NAMESPACE)
+
+
+        # We generate the XML Config file
+
+        root = etree.Element("{" + SYMBOLS_NAMESPACE + "}symbols")
+        root.set('file-path', str(filepath))
+
+        # Symbols
+        for symbol in symbols:
+            symbol.saveToXML(root, SYMBOLS_NAMESPACE, COMMON_NAMESPACE)
+        # Sessions
+        sessions = set()
+        for symbol in symbols:
+            for msg in symbol.messages:
+                from netzob.Model.Vocabulary.Session import Session
+                if msg.session is not None and isinstance(msg.session, Session):
+                    sessions.add(msg.session)
+        for session in sessions:
+            session.saveToXML(root, SYMBOLS_NAMESPACE, COMMON_NAMESPACE)
+
+
+        tree = ElementTree(root)
+
+        tree.write(filepath, pretty_print=True)
+
+    @staticmethod
+    @typeCheck(str)
+    def loadFromXML(filePath):
+        xmlHandler = XMLHandler()
+        tree = ElementTree()
+
+        tree.parse(filePath)
+
+        xmlroot = tree.getroot()
+
+        etree.register_namespace('netzob', SYMBOLS_NAMESPACE)
+        etree.register_namespace('netzob-common', COMMON_NAMESPACE)
+
+
+        # Restore Symbols
+        symbols = []
+        for xmlSymbol in xmlroot.findall("{" + SYMBOLS_NAMESPACE + "}symbol"):
+                symbol = Symbol.loadFromXML(xmlSymbol, SYMBOLS_NAMESPACE, COMMON_NAMESPACE)
+                if symbol is not None:
+                    symbols.append(symbol)
+        # Restore Sessions
+        sessions = []
+        from netzob.Model.Vocabulary.Session import Session
+        for xmlSymbol in xmlroot.findall("{" + SYMBOLS_NAMESPACE + "}session"):
+            session = Session.loadFromXML(xmlSymbol, SYMBOLS_NAMESPACE, COMMON_NAMESPACE)
+            if session is not None:
+                sessions.append(session)
+
+        # Handling of the delayed creation of some references
+        if len(sessions) > 0:
+            session_resolve_dict = dict()
+            for s in sessions:
+                session_resolve_dict[s.id] = session
+
+        message_resolve_dict = dict()
+        for sym in symbols:
+            for msg in sym.messages:
+                message_resolve_dict[msg.id] = msg
+
+        field_resolve_dict = dict()
+        for sym in symbols:
+            for field in sym.getLeafFields():
+                field_resolve_dict[field.id] = field
+
+
+        for case, unresolved in XMLHandler.unresolved_dict.items():
+            if case == 'session':
+                pass
+            elif case == 'fieldDependencies':
+                for key, rel_field in unresolved.items():
+                    if key in field_resolve_dict.keys():
+                        # We get the Field, which belongs in the Dependencies-List of our target Relation Field
+                        f = field_resolve_dict[key]
+                        # We get the current Fields in the Dependencies-List and add our new field to it
+                        curr_Dependencies = rel_field.fieldDependencies
+                        curr_Dependencies.append(f)
+                        rel_field.fieldDependencies = list(curr_Dependencies)
+                        # But the internal field property of the Size Field is still missing so we add that too
+                        from netzob.Model.Vocabulary.Domain.Variables.Leafs.Size import Size
+                        if isinstance(rel_field, Size):
+                            rel_field.fields = curr_Dependencies
+            elif case == 'messages':
+                for key, session in unresolved.items():
+                    if key in message_resolve_dict.keys():
+                        msg = message_resolve_dict[key]
+                        curr_msgs = session.messages.values()
+                        curr_msgs.append(msg)
+                        session.messages = [msg]
+            else:
+                xmlHandler._logger.error("Cannot find a compatible protocol for {}.".format(case))
+
+        symbols.extend(sessions)
+
+        return symbols

--- a/netzob/src/netzob/Export/XMLHandler/all.py
+++ b/netzob/src/netzob/Export/XMLHandler/all.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#+---------------------------------------------------------------------------+
+#|          01001110 01100101 01110100 01111010 01101111 01100010            |
+#|                                                                           |
+#|               Netzob : Inferring communication protocols                  |
+#+---------------------------------------------------------------------------+
+#| Copyright (C) 2011-2017 Georges Bossert and Frédéric Guihéry              |
+#| This program is free software: you can redistribute it and/or modify      |
+#| it under the terms of the GNU General Public License as published by      |
+#| the Free Software Foundation, either version 3 of the License, or         |
+#| (at your option) any later version.                                       |
+#|                                                                           |
+#| This program is distributed in the hope that it will be useful,           |
+#| but WITHOUT ANY WARRANTY; without even the implied warranty of            |
+#| MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              |
+#| GNU General Public License for more details.                              |
+#|                                                                           |
+#| You should have received a copy of the GNU General Public License         |
+#| along with this program. If not, see <http://www.gnu.org/licenses/>.      |
+#+---------------------------------------------------------------------------+
+#| @url      : http://www.netzob.org                                         |
+#| @contact  : contact@netzob.org                                            |
+#| @sponsors : Amossys, http://www.amossys.fr                                |
+#|             Supélec, http://www.rennes.supelec.fr/ren/rd/cidre/           |
+#+---------------------------------------------------------------------------+
+
+# List subpackages to import with the current one
+# see docs.python.org/2/tutorial/modules.html
+
+from netzob.Export.XMLHandler.XMLHandler import *

--- a/netzob/src/netzob/Model/Vocabulary/ApplicativeData.py
+++ b/netzob/src/netzob/Model/Vocabulary/ApplicativeData.py
@@ -33,7 +33,8 @@ import uuid
 #+---------------------------------------------------------------------------+
 #| Related third party imports
 #+---------------------------------------------------------------------------+
-
+from lxml import etree
+from lxml.etree import ElementTree
 #+---------------------------------------------------------------------------+
 #| Local application imports
 #+---------------------------------------------------------------------------+
@@ -117,3 +118,96 @@ class ApplicativeData(object):
         :rtype: str
         """
         return "Applicative Data: {0}={1})".format(self.name, self.value)
+
+    def XMLProperties(currentAppData, xmlSession, symbol_namespace, common_namespace):
+        # Save the properties
+
+        if currentAppData.id is not None:
+            xmlSession.set("id", str(currentAppData.id.hex))
+        if currentAppData.name is not None:
+            xmlSession.set("name", str(currentAppData.name))
+
+        # Save the value
+        if currentAppData.value is not None:
+            xmlValue= etree.SubElement(xmlSession, "{" + symbol_namespace + "}value")
+            currentAppData.value.saveToXML(xmlValue, symbol_namespace, common_namespace)
+
+    def saveToXML(self, xmlRoot, symbol_namespace, common_namespace):
+        xmlSession = etree.SubElement(xmlRoot, "{" + symbol_namespace + "}applicativeData")
+        ApplicativeData.XMLProperties(self, xmlSession, symbol_namespace, common_namespace)
+
+    @staticmethod
+    def restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes):
+
+        if xmlroot.get('id') is not None:
+            attributes['id'] = uuid.UUID(hex=str(xmlroot.get('id')))
+        if xmlroot.get('name') is not None:
+            attributes['name'] = str(xmlroot.get('name'))
+        else:
+            attributes['name'] = None
+
+        value = None
+        if xmlroot.find("{" + symbol_namespace + "}value") is not None:
+            xmlVale = xmlroot.find("{" + symbol_namespace + "}value")
+            if xmlVale.find("{" + symbol_namespace + "}raw") is not None:
+                xmlRaw = xmlVale.find("{" + symbol_namespace + "}raw")
+                from netzob.Model.Vocabulary.Types.Raw import Raw
+                raw = Raw.loadFromXML(xmlRaw, symbol_namespace, common_namespace)
+                if raw is not None:
+                    value = raw
+            elif xmlVale.find("{" + symbol_namespace + "}ascii") is not None:
+                xmlASCII = xmlVale.find("{" + symbol_namespace + "}ascii")
+                from netzob.Model.Vocabulary.Types.ASCII import ASCII
+                ascii = ASCII.loadFromXML(xmlASCII, symbol_namespace, common_namespace)
+                if ascii is not None:
+                    value = ascii
+            elif xmlVale.find("{" + symbol_namespace + "}bitarray") is not None:
+                xmlBitarray = xmlVale.find("{" + symbol_namespace + "}bitarray")
+                from netzob.Model.Vocabulary.Types.BitArray import BitArray
+                bitarray = BitArray.loadFromXML(xmlBitarray, symbol_namespace, common_namespace)
+                if bitarray is not None:
+                    value = bitarray
+            elif xmlVale.find("{" + symbol_namespace + "}hexaString") is not None:
+                xmlHexaString = xmlVale.find("{" + symbol_namespace + "}hexaString")
+                from netzob.Model.Vocabulary.Types.HexaString import HexaString
+                hexastring = HexaString.loadFromXML(xmlHexaString, symbol_namespace, common_namespace)
+                if hexastring is not None:
+                    value = hexastring
+            elif xmlVale.find("{" + symbol_namespace + "}integer") is not None:
+                xmlInteger = xmlVale.find("{" + symbol_namespace + "}integer")
+                from netzob.Model.Vocabulary.Types.Integer import Integer
+                integer = Integer.loadFromXML(xmlInteger, symbol_namespace, common_namespace)
+                if integer is not None:
+                    value = integer
+            elif xmlVale.find("{" + symbol_namespace + "}ipv4") is not None:
+                xmlIPv4 = xmlVale.find("{" + symbol_namespace + "}ipv4")
+                from netzob.Model.Vocabulary.Types.IPv4 import IPv4
+                ipv4 = IPv4.loadFromXML(xmlIPv4, symbol_namespace, common_namespace)
+                if ipv4 is not None:
+                    value = ipv4
+            elif xmlVale.find("{" + symbol_namespace + "}Timestamp") is not None:
+                xmlTimestamp = xmlVale.find("{" + symbol_namespace + "}Timestamp")
+                from netzob.Model.Vocabulary.Types.Timestamp import Timestamp
+                timestamp = Timestamp.loadFromXML(xmlTimestamp, symbol_namespace, common_namespace)
+                if timestamp is not None:
+                    value = timestamp
+            elif xmlVale.find("{" + symbol_namespace + "}abstractType") is not None:
+                xmlAbstractType = xmlVale.find("{" + symbol_namespace + "}abstractType")
+                from netzob.Model.Vocabulary.Types.AbstractType import AbstractType
+                abstractType = AbstractType.loadFromXML(xmlAbstractType, symbol_namespace, common_namespace)
+                if abstractType is not None:
+                    value = abstractType
+        attributes['value'] = value
+
+        return attributes
+
+    @staticmethod
+    def loadFromXML(xmlroot, symbol_namespace, common_namespace):
+
+        a = ApplicativeData.restoreFromXML(xmlroot, symbol_namespace, common_namespace, dict())
+
+        appData = None
+
+        if 'id' in a.keys():
+            appData = ApplicativeData(_id=a['id'], value=a['value'], name=a['name'])
+        return appData

--- a/netzob/src/netzob/Model/Vocabulary/Domain/Variables/AbstractVariable.py
+++ b/netzob/src/netzob/Model/Vocabulary/Domain/Variables/AbstractVariable.py
@@ -40,6 +40,8 @@ import uuid
 #| Related third party imports                                               |
 #+---------------------------------------------------------------------------+
 from bitarray import bitarray
+from lxml import etree
+from lxml.etree import ElementTree
 
 #+---------------------------------------------------------------------------+
 #| Local application imports                                                 |
@@ -298,3 +300,47 @@ class AbstractVariable(object):
     #     self.__fathers = []
     #     for father in fathers:
     #         self.__fathers.append(father)
+
+    def XMLProperties(currentNode, xmlAbsVar, symbol_namespace, common_namespace):
+        if currentNode.id is not None:
+            xmlAbsVar.set("id", str(currentNode.id.hex))
+        if currentNode.varType is not None:
+            xmlAbsVar.set("varType", str(currentNode.varType))
+        if currentNode.name is not None:
+            xmlAbsVar.set("name", str(currentNode.name))
+        if currentNode.svas is not None:
+            xmlAbsVar.set("svas", str(currentNode.svas))
+
+    def saveToXML(self, xmlroot, symbol_namespace, common_namespace):
+        xmlAbsVar = etree.SubElement(xmlroot, "{" + symbol_namespace + "}abstractVariable")
+
+        AbstractVariable.XMLProperties(self, xmlAbsVar, symbol_namespace, common_namespace)
+
+    @staticmethod
+    def restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes):
+
+        if xmlroot.get('varType') is not None:
+            attributes['varType'] = str(xmlroot.get('varType'))
+        if xmlroot.get('id') is not None:
+            s = str(xmlroot.get('id'))
+            attributes['id'] = uuid.UUID(hex=str(xmlroot.get('id')))
+        if xmlroot.get('name') is not None:
+            attributes['name'] = str(xmlroot.get('name'))
+        else:
+            attributes['name'] = None
+        if xmlroot.get('svas') is not None:
+            attributes['svas'] = str(xmlroot.get('svas'))
+        else:
+            attributes['svas'] = None
+        return attributes
+
+    @staticmethod
+    def loadFromXML(xmlroot, symbol_namespace, common_namespace):
+
+        a = AbstractVariable.restoreFromXML(xmlroot, symbol_namespace, common_namespace, dict())
+
+        absVar = None
+
+        if 'varType' in a.keys() and 'id' in a.keys():
+            absVar = AbstractVariable(varType=a['varType'], varId=a['id'], name=a['name'], svas=a['svas'])
+        return absVar

--- a/netzob/src/netzob/Model/Vocabulary/Domain/Variables/Leafs/AbstractVariableLeaf.py
+++ b/netzob/src/netzob/Model/Vocabulary/Domain/Variables/Leafs/AbstractVariableLeaf.py
@@ -39,7 +39,8 @@ import abc
 # +---------------------------------------------------------------------------+
 # | Related third party imports                                               |
 # +---------------------------------------------------------------------------+
-
+from lxml import etree
+from lxml.etree import ElementTree
 # +---------------------------------------------------------------------------+
 # | Local application imports                                                 |
 # +---------------------------------------------------------------------------+
@@ -147,3 +148,30 @@ class AbstractVariableLeaf(AbstractVariable):
         tab.append("|--   ")
         tab.append("{0}".format(self))
         return ''.join(tab)
+
+    def XMLProperties(currentNode, xmlAbsVarLeaf, symbol_namespace, common_namespace):
+        AbstractVariable.XMLProperties(currentNode, xmlAbsVarLeaf, symbol_namespace, common_namespace)
+
+    def saveToXML(self, xmlroot, symbol_namespace, common_namespace):
+        xmlAbsVarLeaf = etree.SubElement(xmlroot, "{" + symbol_namespace + "}abstractVariableLeaf")
+
+        AbstractVariableLeaf.XMLProperties(self, xmlAbsVarLeaf, symbol_namespace, common_namespace)
+
+    @staticmethod
+    def restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes):
+
+        AbstractVariable.restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes)
+        return attributes
+
+    @staticmethod
+    def loadFromXML(xmlroot, symbol_namespace, common_namespace):
+
+        a = AbstractVariableLeaf.restoreFromXML(xmlroot, symbol_namespace, common_namespace, dict())
+
+        absVarLeaf = None
+
+        if 'varType' in a.keys() and 'id' in a.keys():
+            absVarLeaf = AbstractVariableLeaf(varType=a['varType'], name=a['name'], svas=a['svas'])
+            if 'id' in a.keys():
+                absVarLeaf.id = a['id']
+        return absVarLeaf

--- a/netzob/src/netzob/Model/Vocabulary/Domain/Variables/Leafs/InternetChecksum.py
+++ b/netzob/src/netzob/Model/Vocabulary/Domain/Variables/Leafs/InternetChecksum.py
@@ -40,6 +40,8 @@ import random
 #| Related third party imports                                               |
 #+---------------------------------------------------------------------------+
 from bitarray import bitarray
+from lxml import etree
+from lxml.etree import ElementTree
 
 #+---------------------------------------------------------------------------+
 #| Local application imports                                                 |
@@ -328,3 +330,100 @@ class InternetChecksum(AbstractRelationVariableLeaf):
             raise ValueError(
                 "The datatype of a checksum field must declare its length")
         self.__dataType = dataType
+
+    def XMLProperties(currentNode, xmlCkSum, symbol_namespace, common_namespace):
+        AbstractRelationVariableLeaf.XMLProperties(currentNode, xmlCkSum, symbol_namespace, common_namespace)
+
+        # Save the DataType
+        if currentNode.dataType is not None:
+            xmlDataType = etree.SubElement(xmlCkSum, "{" + symbol_namespace + "}datatype")
+            currentNode.dataType.saveToXML(xmlDataType, symbol_namespace, common_namespace)
+
+    def saveToXML(self, xmlroot, symbol_namespace, common_namespace):
+        xmlCkSum = etree.SubElement(xmlroot, "{" + symbol_namespace + "}checksum")
+
+        InternetChecksum.XMLProperties(self, xmlCkSum, symbol_namespace, common_namespace)
+
+    @staticmethod
+    def restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes):
+
+        dataType = None
+        if xmlroot.find("{" + symbol_namespace + "}datatype") is not None:
+            xmlDataType = xmlroot.find("{" + symbol_namespace + "}datatype")
+            if xmlDataType.find("{" + symbol_namespace + "}raw") is not None:
+                xmlRaw = xmlDataType.find("{" + symbol_namespace + "}raw")
+                from netzob.Model.Vocabulary.Types.Raw import Raw
+                raw = Raw.loadFromXML(xmlRaw, symbol_namespace, common_namespace)
+                if raw is not None:
+                    dataType = raw
+            elif xmlDataType.find("{" + symbol_namespace + "}ascii") is not None:
+                xmlASCII = xmlDataType.find("{" + symbol_namespace + "}ascii")
+                from netzob.Model.Vocabulary.Types.ASCII import ASCII
+                ascii = ASCII.loadFromXML(xmlASCII, symbol_namespace, common_namespace)
+                if ascii is not None:
+                    dataType = ascii
+            elif xmlDataType.find("{" + symbol_namespace + "}bitarray") is not None:
+                xmlBitarray = xmlDataType.find("{" + symbol_namespace + "}bitarray")
+                from netzob.Model.Vocabulary.Types.BitArray import BitArray
+                bitarray = BitArray.loadFromXML(xmlBitarray, symbol_namespace, common_namespace)
+                if bitarray is not None:
+                    dataType = bitarray
+            elif xmlDataType.find("{" + symbol_namespace + "}hexaString") is not None:
+                xmlHexaString = xmlDataType.find("{" + symbol_namespace + "}hexaString")
+                from netzob.Model.Vocabulary.Types.HexaString import HexaString
+                hexastring = HexaString.loadFromXML(xmlHexaString, symbol_namespace, common_namespace)
+                if hexastring is not None:
+                    dataType = hexastring
+            elif xmlDataType.find("{" + symbol_namespace + "}integer") is not None:
+                xmlInteger = xmlDataType.find("{" + symbol_namespace + "}integer")
+                from netzob.Model.Vocabulary.Types.Integer import Integer
+                integer = Integer.loadFromXML(xmlInteger, symbol_namespace, common_namespace)
+                if integer is not None:
+                    dataType = integer
+            elif xmlDataType.find("{" + symbol_namespace + "}ipv4") is not None:
+                xmlIPv4 = xmlDataType.find("{" + symbol_namespace + "}ipv4")
+                from netzob.Model.Vocabulary.Types.IPv4 import IPv4
+                ipv4 = IPv4.loadFromXML(xmlIPv4, symbol_namespace, common_namespace)
+                if ipv4 is not None:
+                    dataType = ipv4
+            elif xmlDataType.find("{" + symbol_namespace + "}Timestamp") is not None:
+                xmlTimestamp = xmlDataType.find("{" + symbol_namespace + "}Timestamp")
+                from netzob.Model.Vocabulary.Types.Timestamp import Timestamp
+                timestamp = Timestamp.loadFromXML(xmlTimestamp, symbol_namespace, common_namespace)
+                if timestamp is not None:
+                    dataType = timestamp
+            elif xmlDataType.find("{" + symbol_namespace + "}abstractType") is not None:
+                xmlAbstractType = xmlDataType.find("{" + symbol_namespace + "}abstractType")
+                from netzob.Model.Vocabulary.Types.AbstractType import AbstractType
+                abstractType = AbstractType.loadFromXML(xmlAbstractType, symbol_namespace, common_namespace)
+                if abstractType is not None:
+                    dataType = abstractType
+
+        attributes['dataType'] = dataType
+
+        AbstractRelationVariableLeaf.restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes)
+
+        return attributes
+
+    @staticmethod
+    def loadFromXML(xmlroot, symbol_namespace, common_namespace):
+
+        a = InternetChecksum.restoreFromXML(xmlroot, symbol_namespace, common_namespace, dict())
+
+        checksum = None
+
+        if 'fieldDependencies' in a.keys():
+            checksum = InternetChecksum(dataType=a['dataType'], name=a['name'], fields=list())
+            if 'id' in a.keys():
+                checksum.id = a['id']
+            if 'svas' in a.keys():
+                checksum.svas = a['svas']
+            if 'fieldDependencies' in a.keys():
+                from netzob.Export.XMLHandler.XMLHandler import XMLHandler
+                unresolved = dict()
+                for ref in a['fieldDependencies']:
+                    unresolved[ref] = checksum
+                XMLHandler.add_to_unresolved_dict('fieldDependencies', unresolved)
+        return checksum
+
+

--- a/netzob/src/netzob/Model/Vocabulary/Domain/Variables/Leafs/Size.py
+++ b/netzob/src/netzob/Model/Vocabulary/Domain/Variables/Leafs/Size.py
@@ -40,7 +40,8 @@
 #| Related third party imports                                               |
 #+---------------------------------------------------------------------------+
 from bitarray import bitarray
-
+from lxml import etree
+from lxml.etree import ElementTree
 #+---------------------------------------------------------------------------+
 #| Local application imports                                                 |
 #+---------------------------------------------------------------------------+
@@ -428,3 +429,114 @@ class Size(AbstractRelationVariableLeaf):
             raise TypeError(
                 "Offset cannot be None, use 0 if no offset should be applied.")
         self.__offset = offset
+
+    def XMLProperties(currentNode, xmlSize, symbol_namespace, common_namespace):
+        AbstractRelationVariableLeaf.XMLProperties(currentNode, xmlSize, symbol_namespace, common_namespace)
+
+        # Save Properies
+        if currentNode.factor is not None:
+            xmlSize.set("factor", str(currentNode.factor))
+        if currentNode.offset is not None:
+            xmlSize.set("offset", str(currentNode.offset))
+
+        # Save the DataType
+        if currentNode.dataType is not None:
+            xmlDataType = etree.SubElement(xmlSize, "{" + symbol_namespace + "}datatype")
+            currentNode.dataType.saveToXML(xmlDataType, symbol_namespace, common_namespace)
+
+
+    def saveToXML(self, xmlroot, symbol_namespace, common_namespace):
+        xmlSize = etree.SubElement(xmlroot, "{" + symbol_namespace + "}size")
+
+        Size.XMLProperties(self, xmlSize, symbol_namespace, common_namespace)
+
+    @staticmethod
+    def restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes):
+
+        if xmlroot.get('factor') is not None:
+            attributes['factor'] = float(xmlroot.get('factor'))
+        else:
+            attributes['factor'] = None
+        if xmlroot.get('offset') is not None:
+            attributes['offset'] = int(xmlroot.get('offset'))
+        else:
+            attributes['offset'] = None
+
+        dataType = None
+        if xmlroot.find("{" + symbol_namespace + "}datatype") is not None:
+            xmlDataType = xmlroot.find("{" + symbol_namespace + "}datatype")
+            if xmlDataType.find("{" + symbol_namespace + "}raw") is not None:
+                xmlRaw = xmlDataType.find("{" + symbol_namespace + "}raw")
+                from netzob.Model.Vocabulary.Types.Raw import Raw
+                raw = Raw.loadFromXML(xmlRaw, symbol_namespace, common_namespace)
+                if raw is not None:
+                    dataType = raw
+            elif xmlDataType.find("{" + symbol_namespace + "}ascii") is not None:
+                xmlASCII = xmlDataType.find("{" + symbol_namespace + "}ascii")
+                from netzob.Model.Vocabulary.Types.ASCII import ASCII
+                ascii = ASCII.loadFromXML(xmlASCII, symbol_namespace, common_namespace)
+                if ascii is not None:
+                    dataType = ascii
+            elif xmlDataType.find("{" + symbol_namespace + "}bitarray") is not None:
+                xmlBitarray = xmlDataType.find("{" + symbol_namespace + "}bitarray")
+                from netzob.Model.Vocabulary.Types.BitArray import BitArray
+                bitarray = BitArray.loadFromXML(xmlBitarray, symbol_namespace, common_namespace)
+                if bitarray is not None:
+                    dataType = bitarray
+            elif xmlDataType.find("{" + symbol_namespace + "}hexaString") is not None:
+                xmlHexaString = xmlDataType.find("{" + symbol_namespace + "}hexaString")
+                from netzob.Model.Vocabulary.Types.HexaString import HexaString
+                hexastring = HexaString.loadFromXML(xmlHexaString, symbol_namespace, common_namespace)
+                if hexastring is not None:
+                    dataType = hexastring
+            elif xmlDataType.find("{" + symbol_namespace + "}integer") is not None:
+                xmlInteger = xmlDataType.find("{" + symbol_namespace + "}integer")
+                from netzob.Model.Vocabulary.Types.Integer import Integer
+                integer = Integer.loadFromXML(xmlInteger, symbol_namespace, common_namespace)
+                if integer is not None:
+                    dataType = integer
+            elif xmlDataType.find("{" + symbol_namespace + "}ipv4") is not None:
+                xmlIPv4 = xmlDataType.find("{" + symbol_namespace + "}ipv4")
+                from netzob.Model.Vocabulary.Types.IPv4 import IPv4
+                ipv4 = IPv4.loadFromXML(xmlIPv4, symbol_namespace, common_namespace)
+                if ipv4 is not None:
+                    dataType = ipv4
+            elif xmlDataType.find("{" + symbol_namespace + "}Timestamp") is not None:
+                xmlTimestamp = xmlDataType.find("{" + symbol_namespace + "}Timestamp")
+                from netzob.Model.Vocabulary.Types.Timestamp import Timestamp
+                timestamp = Timestamp.loadFromXML(xmlTimestamp, symbol_namespace, common_namespace)
+                if timestamp is not None:
+                    dataType = timestamp
+            elif xmlDataType.find("{" + symbol_namespace + "}abstractType") is not None:
+                xmlAbstractType = xmlDataType.find("{" + symbol_namespace + "}abstractType")
+                from netzob.Model.Vocabulary.Types.AbstractType import AbstractType
+                abstractType = AbstractType.loadFromXML(xmlAbstractType, symbol_namespace, common_namespace)
+                if abstractType is not None:
+                    dataType = abstractType
+
+        attributes['dataType'] = dataType
+
+        AbstractRelationVariableLeaf.restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes)
+
+        return attributes
+
+    @staticmethod
+    def loadFromXML(xmlroot, symbol_namespace, common_namespace):
+
+        a = Size.restoreFromXML(xmlroot, symbol_namespace, common_namespace, dict())
+
+        size = None
+
+        if 'fieldDependencies' in a.keys():
+            size = Size(dataType=a['dataType'], offset=a['offset'], factor=a['factor'], name=a['name'], fields=list())
+            if 'id' in a.keys():
+                size.id = a['id']
+            if 'svas' in a.keys():
+                size.svas = a['svas']
+            if 'fieldDependencies' in a.keys():
+                from netzob.Export.XMLHandler.XMLHandler import XMLHandler
+                unresolved = dict()
+                for ref in a['fieldDependencies']:
+                    unresolved[ref] = size
+                XMLHandler.add_to_unresolved_dict('fieldDependencies', unresolved)
+        return size

--- a/netzob/src/netzob/Model/Vocabulary/Domain/Variables/Leafs/Value.py
+++ b/netzob/src/netzob/Model/Vocabulary/Domain/Variables/Leafs/Value.py
@@ -39,7 +39,8 @@
 #| Related third party imports                                               |
 #+---------------------------------------------------------------------------+
 from bitarray import bitarray
-
+from lxml import etree
+from lxml.etree import ElementTree
 #+---------------------------------------------------------------------------+
 #| Local application imports                                                 |
 #+---------------------------------------------------------------------------+
@@ -366,3 +367,73 @@ class Value(AbstractRelationVariableLeaf):
         if operation is not None and not callable(operation):
             raise TypeError("Operation must be a function")
         self.__operation = operation
+
+    def XMLProperties(currentNode, xmlValue, symbol_namespace, common_namespace):
+        AbstractRelationVariableLeaf.XMLProperties(currentNode, xmlValue, symbol_namespace, common_namespace)
+
+        # Save Properties
+        # if currentNode.factor is not None:
+        #     xmlValue.set("factor", str(currentNode.factor))
+        # if currentNode.offset is not None:
+        #     xmlValue.set("offset", str(currentNode.offset))
+        # Maybe not supported
+        # if currentNode.operation is not None:
+            # xmlValue.set("operation", str(currentNode.operation))
+
+        # Save the DataType
+        # if currentNode.dataType is not None:
+        #     currentNode.dataType.saveToXML(xmlValue, symbol_namespace, common_namespace)
+
+    def saveToXML(self, xmlroot, symbol_namespace, common_namespace):
+        xmlValue = etree.SubElement(xmlroot, "{" + symbol_namespace + "}value")
+
+        Value.XMLProperties(self, xmlValue, symbol_namespace, common_namespace)
+
+    @staticmethod
+    def restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes):
+
+        # if xmlroot.get('factor') is not None:
+        #     attributes['factor'] = float(xmlroot.get('factor'))
+        # else:
+        #     attributes['factor'] = None
+        # if xmlroot.get('offset') is not None:
+        #     attributes['offset'] = int(xmlroot.get('offset'))
+        # else:
+        #     attributes['offset'] = None
+        AbstractRelationVariableLeaf.restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes)
+
+        return attributes
+
+    @staticmethod
+    def loadFromXML(xmlroot, symbol_namespace, common_namespace):
+
+        a = Value.restoreFromXML(xmlroot, symbol_namespace, common_namespace, dict())
+
+        value = None
+
+        if 'fieldDependencies' in a.keys():
+            from netzob.Model.Vocabulary.Field import Field
+            value = Value(name=a['name'], field=Field())
+            if 'id' in a.keys():
+                value.id = a['id']
+            if 'svas' in a.keys():
+                value.svas = a['svas']
+            # if 'factor' in a.keys():
+            #     value.factor = a['factor']
+            # if 'offset' in a.keys():
+            #     value.offset = a['offset']
+            # TODO: Operation is missing. No way to save operation yet
+            if 'fieldDependencies' in a.keys():
+                from netzob.Export.XMLHandler.XMLHandler import XMLHandler
+                # remove placeholder field again
+                value.fieldDependencies = []
+                unresolved = dict()
+                for ref in a['fieldDependencies']:
+                    unresolved[ref] = value
+                XMLHandler.add_to_unresolved_dict('fieldDependencies', unresolved)
+        return value
+
+
+
+
+

--- a/netzob/src/netzob/Model/Vocabulary/Domain/Variables/Nodes/AbstractVariableNode.py
+++ b/netzob/src/netzob/Model/Vocabulary/Domain/Variables/Nodes/AbstractVariableNode.py
@@ -38,7 +38,8 @@
 # +---------------------------------------------------------------------------+
 # | Related third party imports                                               |
 # +---------------------------------------------------------------------------+
-
+from lxml import etree
+from lxml.etree import ElementTree
 # +---------------------------------------------------------------------------+
 # | Local application imports                                                 |
 # +---------------------------------------------------------------------------+
@@ -90,3 +91,100 @@ class AbstractVariableNode(AbstractVariable):
         for f in self.children:
             lines.append(" " + f._str_debug(deepness + 1))
         return '\n'.join(lines)
+
+    def XMLProperties(currentNode, xmlAbsVarNode, symbol_namespace, common_namespace):
+        AbstractVariable.XMLProperties(currentNode, xmlAbsVarNode, symbol_namespace, common_namespace)
+
+        if currentNode.children is not None and len(currentNode.children) > 0:
+            xmlChildren = etree.SubElement(xmlAbsVarNode, "{" + symbol_namespace + "}children")
+            for child in currentNode.children:
+                child.saveToXML(xmlChildren, symbol_namespace, common_namespace)
+
+    def saveToXML(self, xmlroot, symbol_namespace, common_namespace):
+        xmlAbsVarNode = etree.SubElement(xmlroot, "{" + symbol_namespace + "}abstractVariableNode")
+
+        AbstractVariableNode.XMLProperties(self, xmlAbsVarNode, symbol_namespace, common_namespace)
+
+    @staticmethod
+    def restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes):
+        from netzob.Model.Vocabulary.Domain.Variables.AbstractVariable import AbstractVariable
+
+        children = []
+        if xmlroot.find("{" + symbol_namespace + "}children") is not None:
+            xmlChildren= xmlroot.find("{" + symbol_namespace + "}children")
+            for xmlData in xmlChildren.findall("{" + symbol_namespace + "}data"):
+                from netzob.Model.Vocabulary.Domain.Variables.Leafs.Data import Data
+                data = Data.loadFromXML(xmlData, symbol_namespace, common_namespace)
+                if data is not None:
+                    children.append(data)
+            for xmlValue in xmlChildren.findall("{" + symbol_namespace + "}value"):
+                from netzob.Model.Vocabulary.Domain.Variables.Leafs.Value import Value
+                value = Value.loadFromXML(xmlValue, symbol_namespace, common_namespace)
+                if value is not None:
+                    children.append(value)
+            for xmlSize in xmlChildren.findall("{" + symbol_namespace + "}size"):
+                from netzob.Model.Vocabulary.Domain.Variables.Leafs.Size import Size
+                size = Size.loadFromXML(xmlSize, symbol_namespace, common_namespace)
+                if size is not None:
+                    children.append(size)
+            for xmlChecksum in xmlChildren.findall("{" + symbol_namespace + "}checksum"):
+                from netzob.Model.Vocabulary.Domain.Variables.Leafs.InternetChecksum import InternetChecksum
+                checksum = InternetChecksum.loadFromXML(xmlChecksum, symbol_namespace, common_namespace)
+                if checksum is not None:
+                    children.append(checksum)
+            for xmlAgg in xmlChildren.findall("{" + symbol_namespace + "}aggregation"):
+                from netzob.Model.Vocabulary.Domain.Variables.Nodes.Agg import Agg
+                agg = Agg.loadFromXML(xmlAgg, symbol_namespace, common_namespace)
+                if agg is not None:
+                    children.append(agg)
+            for xmlAlt in xmlChildren.findall("{" + symbol_namespace + "}alternative"):
+                from netzob.Model.Vocabulary.Domain.Variables.Nodes.Alt import Alt
+                alt = Alt.loadFromXML(xmlAlt, symbol_namespace, common_namespace)
+                if alt is not None:
+                    children.append(alt)
+            for xmlRepeat in xmlChildren.findall("{" + symbol_namespace + "}repeat"):
+                from netzob.Model.Vocabulary.Domain.Variables.Nodes.Repeat import Repeat
+                repeat = Repeat.loadFromXML(xmlRepeat, symbol_namespace, common_namespace)
+                if repeat is not None:
+                    children.append(repeat)
+            for xmlabsRelVarLeaf in xmlChildren.findall("{" + symbol_namespace + "}abstractRelationVariableLeaf"):
+                from netzob.Model.Vocabulary.Domain.Variables.Leafs.AbstractRelationVariableLeaf import AbstractRelationVariableLeaf
+                absRelVarLeaf = AbstractRelationVariableLeaf.loadFromXML(xmlabsRelVarLeaf, symbol_namespace, common_namespace)
+                if absRelVarLeaf is not None:
+                    children.append(absRelVarLeaf)
+            for xmlabsVarLeaf in xmlChildren.findall("{" + symbol_namespace + "}abstractVariableLeaf"):
+                from netzob.Model.Vocabulary.Domain.Variables.Leafs.AbstractVariableLeaf import AbstractVariableLeaf
+                absVarLeaf = AbstractVariableLeaf.loadFromXML(xmlabsVarLeaf, symbol_namespace, common_namespace)
+                if absVarLeaf is not None:
+                    children.append(absVarLeaf)
+            for xmlabstractVariableNode in xmlChildren.findall("{" + symbol_namespace + "}abstractVariableNode"):
+                from netzob.Model.Vocabulary.Domain.Variables.Nodes.AbstractVariableNode import AbstractVariableNode
+                abstractVariableNode = AbstractVariableNode.loadFromXML(xmlabstractVariableNode, symbol_namespace, common_namespace)
+                if abstractVariableNode is not None:
+                    children.append(abstractVariableNode)
+            for xmlabstractVariable in xmlChildren.findall("{" + symbol_namespace + "}abstractVariable"):
+                abstractVariable = AbstractVariable.loadFromXML(xmlabstractVariable, symbol_namespace, common_namespace)
+                if abstractVariable is not None:
+                    children.append(abstractVariable)
+        attributes['children'] = children
+
+        AbstractVariable.restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes)
+
+        return attributes
+
+    @staticmethod
+    def loadFromXML(xmlroot, symbol_namespace, common_namespace):
+
+        a = AbstractVariableNode.restoreFromXML(xmlroot, symbol_namespace, common_namespace, dict())
+
+        absVarNode = None
+
+        if 'varType' in a.keys() and 'id' in a.keys():
+            absVarNode = AbstractVariableNode(varType=a['varType'], children=a['children'], svas=a['svas'])
+            if 'id' in a.keys():
+                absVarNode.id = a['id']
+            if 'name' in a.keys():
+                absVarNode.name = a['name']
+        return absVarNode
+
+

--- a/netzob/src/netzob/Model/Vocabulary/Domain/Variables/Nodes/Agg.py
+++ b/netzob/src/netzob/Model/Vocabulary/Domain/Variables/Nodes/Agg.py
@@ -38,7 +38,8 @@
 # +---------------------------------------------------------------------------+
 # | Related third party imports                                               |
 # +---------------------------------------------------------------------------+
-
+from lxml import etree
+from lxml.etree import ElementTree
 # +---------------------------------------------------------------------------+
 # | Local application imports                                                 |
 # +---------------------------------------------------------------------------+
@@ -231,3 +232,33 @@ class Agg(AbstractVariableNode):
 
         # ok we managed to parse all the children, and it produced some valid specializer paths. We return them
         return specializingPaths
+
+    def XMLProperties(currentNode, xmlAgg, symbol_namespace, common_namespace):
+        AbstractVariableNode.XMLProperties(currentNode, xmlAgg, symbol_namespace, common_namespace)
+
+    def saveToXML(self, xmlroot, symbol_namespace, common_namespace):
+        xmlAgg = etree.SubElement(xmlroot, "{" + symbol_namespace + "}aggregation")
+
+        Agg.XMLProperties(self, xmlAgg, symbol_namespace, common_namespace)
+
+    @staticmethod
+    def restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes):
+        AbstractVariableNode.restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes)
+        return attributes
+
+    @staticmethod
+    def loadFromXML(xmlroot, symbol_namespace, common_namespace):
+
+        a = Agg.restoreFromXML(xmlroot, symbol_namespace, common_namespace, dict())
+
+        agg = None
+
+        if 'children' in a.keys() and 'svas' in a.keys():
+            agg = Agg(children=a['children'], svas=a['svas'])
+            if 'id' in a.keys():
+                agg.id = a['id']
+            if 'name' in a.keys():
+                agg.name = a['name']
+        return agg
+
+

--- a/netzob/src/netzob/Model/Vocabulary/Domain/Variables/Nodes/Alt.py
+++ b/netzob/src/netzob/Model/Vocabulary/Domain/Variables/Nodes/Alt.py
@@ -39,7 +39,8 @@ import random
 #+---------------------------------------------------------------------------+
 #| Related third party imports                                               |
 #+---------------------------------------------------------------------------+
-
+from lxml import etree
+from lxml.etree import ElementTree
 #+---------------------------------------------------------------------------+
 #| Local application imports                                                 |
 #+---------------------------------------------------------------------------+
@@ -180,3 +181,31 @@ class Alt(AbstractVariableNode):
         # lets shuffle this ( :) ) >>> by default we only consider the first valid parsing path.
         random.shuffle(specializingPaths)
         return specializingPaths
+
+    def XMLProperties(currentNode, xmlAlt, symbol_namespace, common_namespace):
+        AbstractVariableNode.XMLProperties(currentNode, xmlAlt, symbol_namespace, common_namespace)
+
+    def saveToXML(self, xmlroot, symbol_namespace, common_namespace):
+        xmlAlt = etree.SubElement(xmlroot, "{" + symbol_namespace + "}alternative")
+
+        Alt.XMLProperties(self, xmlAlt, symbol_namespace, common_namespace)
+
+    @staticmethod
+    def restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes):
+        AbstractVariableNode.restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes)
+        return attributes
+
+    @staticmethod
+    def loadFromXML(xmlroot, symbol_namespace, common_namespace):
+
+        a = Alt.restoreFromXML(xmlroot, symbol_namespace, common_namespace, dict())
+
+        alt = None
+
+        if 'children' in a.keys() and 'svas' in a.keys():
+            alt = Alt(children=a['children'], svas=a['svas'])
+            if 'id' in a.keys():
+                alt.id = a['id']
+            if 'name' in a.keys():
+                alt.name = a['name']
+        return alt

--- a/netzob/src/netzob/Model/Vocabulary/Field.py
+++ b/netzob/src/netzob/Model/Vocabulary/Field.py
@@ -39,7 +39,8 @@
 #+---------------------------------------------------------------------------+
 #| Related third party imports                                               |
 #+---------------------------------------------------------------------------+
-
+from lxml import etree
+from lxml.etree import ElementTree
 #+---------------------------------------------------------------------------+
 #| Local application imports                                                 |
 #+---------------------------------------------------------------------------+
@@ -136,6 +137,15 @@ class Field(AbstractField):
             domain = Raw(None)
         self.domain = domain
         self.isPseudoField = isPseudoField
+<<<<<<< HEAD
+=======
+        self._length = length
+        try:
+            if self.domain.currentValue is not None:
+                self._length = len(self.domain.currentValue)
+        except:
+            self._length = length
+>>>>>>> a39ca26... New Feature: XML-Handler:
 
     def specialize(self):
         """Specialize the current field to build a raw data that
@@ -224,6 +234,20 @@ class Field(AbstractField):
         return messages
 
     @property
+    def length(self):
+        """
+        Length of the Field Property Getter
+        :return: Length as int
+        """
+        return self._length
+
+    @length.setter
+    @typeCheck(int)
+    def length(self, length):
+        if length is None and isinstance(length, int):
+            self._length = length
+
+    @property
     def isPseudoField(self):
         """Flag describing if current field is a isPseudoField.
 
@@ -239,3 +263,141 @@ class Field(AbstractField):
         if isPseudoField is None:
             isPseudoField = False
         self.__isPseudoField = isPseudoField
+
+    def XMLProperties(currentField, xmlField, symbol_namespace, common_namespace):
+        # Save the Properties inherited from  Abstract Field
+        AbstractField.XMLProperties(currentField, xmlField, symbol_namespace, common_namespace)
+
+        if currentField.length is not None:
+            xmlField.set("length", str(currentField.length))
+        if currentField.isPseudoField is not None:
+            xmlField.set("isPseudoField", str(currentField.isPseudoField))
+
+        # Save the Domain
+        if currentField is not None:
+            xmlDomain = etree.SubElement(xmlField, "{" + symbol_namespace + "}domain")
+            currentField.domain.saveToXML(xmlDomain, symbol_namespace, common_namespace)
+
+    def saveToXML(self, xmlroot, symbol_namespace, common_namespace):
+        xmlField = etree.SubElement(xmlroot, "{" + symbol_namespace + "}field")
+
+        Field.XMLProperties(self, xmlField, symbol_namespace, common_namespace)
+
+    @staticmethod
+    def restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes):
+
+        if xmlroot.get('length') is not None:
+            attributes['length'] = int(xmlroot.get('length'))
+        else:
+            attributes['length'] = None
+
+        attributes['isPseudoField'] = xmlroot.get('isPseudoField', 'False') == 'True'
+
+        domain = None
+        if xmlroot.find("{" + symbol_namespace + "}domain") is not None:
+            xmlDomain = xmlroot.find("{" + symbol_namespace + "}domain")
+            if xmlDomain.find("{" + symbol_namespace + "}data") is not None:
+                xmlData = xmlDomain.find("{" + symbol_namespace + "}data")
+                from netzob.Model.Vocabulary.Domain.Variables.Leafs.Data import Data
+                data = Data.loadFromXML(xmlData, symbol_namespace, common_namespace)
+                if data is not None:
+                    domain = data
+            elif xmlDomain.find("{" + symbol_namespace + "}value") is not None:
+                xmlValue = xmlDomain.find("{" + symbol_namespace + "}value")
+                from netzob.Model.Vocabulary.Domain.Variables.Leafs.Value import Value
+                value = Value.loadFromXML(xmlValue, symbol_namespace, common_namespace)
+                if value is not None:
+                    domain = value
+            elif xmlDomain.find("{" + symbol_namespace + "}size") is not None:
+                xmlSize = xmlDomain.find("{" + symbol_namespace + "}size")
+                from netzob.Model.Vocabulary.Domain.Variables.Leafs.Size import Size
+                size = Size.loadFromXML(xmlSize, symbol_namespace, common_namespace)
+                if size is not None:
+                    domain = size
+            elif xmlDomain.find("{" + symbol_namespace + "}checksum") is not None:
+                xmlChecksum = xmlDomain.find("{" + symbol_namespace + "}checksum")
+                from netzob.Model.Vocabulary.Domain.Variables.Leafs.InternetChecksum import InternetChecksum
+                checksum = InternetChecksum.loadFromXML(xmlChecksum, symbol_namespace, common_namespace)
+                if checksum is not None:
+                    domain = checksum
+            elif xmlDomain.find("{" + symbol_namespace + "}aggregation") is not None:
+                xmlAgg = xmlDomain.find("{" + symbol_namespace + "}aggregation")
+                from netzob.Model.Vocabulary.Domain.Variables.Nodes.Agg import Agg
+                agg = Agg.loadFromXML(xmlAgg, symbol_namespace, common_namespace)
+                if agg is not None:
+                    domain = agg
+            elif xmlDomain.find("{" + symbol_namespace + "}alternative") is not None:
+                xmlAlt= xmlDomain.find("{" + symbol_namespace + "}alternative")
+                from netzob.Model.Vocabulary.Domain.Variables.Nodes.Alt import Alt
+                alt = Alt.loadFromXML(xmlAlt, symbol_namespace, common_namespace)
+                if alt is not None:
+                    domain = alt
+            elif xmlDomain.find("{" + symbol_namespace + "}repeat") is not None:
+                xmlRepeat = xmlDomain.find("{" + symbol_namespace + "}repeat")
+                from netzob.Model.Vocabulary.Domain.Variables.Nodes.Repeat import Repeat
+                repeat = Repeat.loadFromXML(xmlRepeat, symbol_namespace, common_namespace)
+                if repeat is not None:
+                    domain = repeat
+            elif xmlDomain.find("{" + symbol_namespace + "}abstractRelationVariableLeaf") is not None:
+                xmlabsRelVarLeaf = xmlDomain.find("{" + symbol_namespace + "}abstractRelationVariableLeaf")
+                from netzob.Model.Vocabulary.Domain.Variables.Leafs.AbstractRelationVariableLeaf import AbstractRelationVariableLeaf
+                absRelVarLeaf = AbstractRelationVariableLeaf.loadFromXML(xmlabsRelVarLeaf, symbol_namespace, common_namespace)
+                if absRelVarLeaf is not None:
+                    domain = absRelVarLeaf
+            elif xmlDomain.find("{" + symbol_namespace + "}abstractVariableLeaf") is not None:
+                xmlabsVarLeaf = xmlDomain.find("{" + symbol_namespace + "}abstractVariableLeaf")
+                from netzob.Model.Vocabulary.Domain.Variables.Leafs.AbstractVariableLeaf import AbstractVariableLeaf
+                absVarLeaf = AbstractVariableLeaf.loadFromXML(xmlabsVarLeaf, symbol_namespace, common_namespace)
+                if absVarLeaf is not None:
+                    domain = absVarLeaf
+            elif xmlDomain.find("{" + symbol_namespace + "}abstractVariableNode") is not None:
+                xmlabstractVariableNode = xmlDomain.find("{" + symbol_namespace + "}abstractVariableNode")
+                from netzob.Model.Vocabulary.Domain.Variables.Nodes.AbstractVariableNode import AbstractVariableNode
+                abstractVariableNode = AbstractVariableNode.loadFromXML(xmlabstractVariableNode, symbol_namespace, common_namespace)
+                if abstractVariableNode is not None:
+                    domain = abstractVariableNode
+            elif xmlDomain.find("{" + symbol_namespace + "}abstractVariable") is not None:
+                xmlabstractVariable = xmlDomain.find("{" + symbol_namespace + "}abstractVariable")
+                from netzob.Model.Vocabulary.Domain.Variables.AbstractVariable import AbstractVariable
+                abstractVariable = AbstractVariable.loadFromXML(xmlabstractVariable, symbol_namespace, common_namespace)
+                if abstractVariable is not None:
+                    domain = abstractVariable
+        attributes['domain'] = domain
+
+        AbstractField.restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes)
+
+        return attributes
+
+    @staticmethod
+    def loadFromXML(xmlroot, symbol_namespace, common_namespace):
+
+        a = Field.restoreFromXML(xmlroot, symbol_namespace, common_namespace, dict())
+
+        field = None
+
+        if 'domain' in a.keys() and 'name' in a.keys():
+            field = Field(domain=a['domain'], name=a['name'], isPseudoField=a['isPseudoField'], length=a['length'])
+            if 'id' in a.keys():
+                field.id = a['id']
+            if 'description' in a.keys():
+                field.description = a['description']
+            if 'fields' in a.keys():
+                field.fields = a['fields']
+            if 'encodingFunctions' in a.keys():
+                field.encodingFunctions = a['encodingFunctions']
+            if 'visualizationFunctions' in a.keys():
+                field.visualizationFunctions = a['visualizationFunctions']
+            # if 'transformationFunctions' in a.keys():
+            #     field.transformationFunctions = a['transformationFunctions']
+
+        return field
+
+
+
+
+
+
+
+
+
+

--- a/netzob/src/netzob/Model/Vocabulary/Functions/EncodingFunctions/Base64EncodingFunction.py
+++ b/netzob/src/netzob/Model/Vocabulary/Functions/EncodingFunctions/Base64EncodingFunction.py
@@ -38,7 +38,8 @@ import base64
 #+---------------------------------------------------------------------------+
 #| Related third party imports                                               |
 #+---------------------------------------------------------------------------+
-
+from lxml import etree
+from lxml.etree import ElementTree
 #+---------------------------------------------------------------------------+
 #| Local application imports                                                 |
 #+---------------------------------------------------------------------------+
@@ -132,3 +133,33 @@ class Base64EncodingFunction(EncodingFunction):
     @typeCheck(bool)        
     def encode_data(self, _encode_data):
         self.__encode_data = _encode_data
+
+    def XMLProperties(currentFunction, xmlBase64EncodingFunction, symbol_namespace, common_namespace):
+        # Save the Properties
+        if currentFunction.encode_data is not None:
+            xmlBase64EncodingFunction.set("encode_data", str(currentFunction.encode_data))
+
+    def saveToXML(self, xmlRoot, symbol_namespace, common_namespace):
+        xmlBase64EncodingFunction = etree.SubElement(xmlRoot, "{" + symbol_namespace + "}Base64EncodingFunction")
+
+        Base64EncodingFunction.XMLProperties(self, xmlBase64EncodingFunction, symbol_namespace, common_namespace)
+
+    @staticmethod
+    def restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes):
+
+        if xmlroot.get('encode_data') is not None:
+            attributes['encode_data'] = str(xmlroot.get('id')) == 'True'
+        else:
+            attributes['encode_data'] = True
+        return attributes
+
+    @staticmethod
+    def loadFromXML(xmlroot, symbol_namespace, common_namespace):
+
+        a = Base64EncodingFunction.restoreFromXML(xmlroot, symbol_namespace, common_namespace, dict())
+
+        base64enc = None
+
+        if 'encode_data' in a.keys():
+            base64enc = Base64EncodingFunction(encode_data=a['encode_data'])
+        return base64enc

--- a/netzob/src/netzob/Model/Vocabulary/Functions/EncodingFunctions/TypeEncodingFunction.py
+++ b/netzob/src/netzob/Model/Vocabulary/Functions/EncodingFunctions/TypeEncodingFunction.py
@@ -38,7 +38,8 @@
 #+---------------------------------------------------------------------------+
 #| Related third party imports                                               |
 #+---------------------------------------------------------------------------+
-
+from lxml import etree
+from lxml.etree import ElementTree
 #+---------------------------------------------------------------------------+
 #| Local application imports                                                 |
 #+---------------------------------------------------------------------------+
@@ -199,3 +200,52 @@ class TypeEncodingFunction(EncodingFunction):
                 "This sign is not supported, please refer to the list of supported type in AbstractType.supportedSign()"
             )
         self.__sign = sign
+
+    def XMLProperties(currentFunction, xmlTypeEncodingFunction, symbol_namespace, common_namespace):
+        # Save the Properties
+        if currentFunction.type is not None:
+            type_nr = AbstractType.supportedTypes().index(currentFunction.type)
+            xmlTypeEncodingFunction.set("type", str(type_nr))
+        if currentFunction.unitSize is not None:
+            xmlTypeEncodingFunction.set("unitSize", str(currentFunction.unitSize))
+        if currentFunction.endianness is not None:
+            xmlTypeEncodingFunction.set("endianness", str(currentFunction.endianness))
+        if currentFunction.sign is not None:
+            xmlTypeEncodingFunction.set("sign", str(currentFunction.sign))
+
+    def saveToXML(self, xmlRoot, symbol_namespace, common_namespace):
+        xmlTypeEncodingFunction = etree.SubElement(xmlRoot, "{" + symbol_namespace + "}TypeEncodingFunction")
+
+        TypeEncodingFunction.XMLProperties(self, xmlTypeEncodingFunction, symbol_namespace, common_namespace)
+
+    @staticmethod
+    def restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes):
+
+        if xmlroot.get('type') is not None:
+            attributes['type'] = AbstractType.supportedTypes()[int(xmlroot.get('type'))]
+        if xmlroot.get('unitSize') is not None:
+            attributes['unitSize'] = str(xmlroot.get('unitSize'))
+        else:
+            attributes['unitSize'] = None
+        if xmlroot.get('endianness') is not None:
+            attributes['endianness'] = str(xmlroot.get('endianness'))
+        else:
+            attributes['endianness'] = None
+        if xmlroot.get('sign') is not None:
+            attributes['sign'] = str(xmlroot.get('sign'))
+        else:
+            attributes['sign'] = None
+        return attributes
+
+    @staticmethod
+    def loadFromXML(xmlroot, symbol_namespace, common_namespace):
+
+        a = TypeEncodingFunction.restoreFromXML(xmlroot, symbol_namespace, common_namespace, dict())
+
+        typeEnc = None
+
+        if 'type' in a.keys():
+            typeEnc = TypeEncodingFunction(_type=a['type'], unitSize=a['unitSize'], endianness=a['endianness'],
+                                           sign=a['sign'])
+        return typeEnc
+

--- a/netzob/src/netzob/Model/Vocabulary/Functions/EncodingFunctions/ZLibEncodingFunction.py
+++ b/netzob/src/netzob/Model/Vocabulary/Functions/EncodingFunctions/ZLibEncodingFunction.py
@@ -38,7 +38,8 @@ import zlib
 #+---------------------------------------------------------------------------+
 #| Related third party imports                                               |
 #+---------------------------------------------------------------------------+
-
+from lxml import etree
+from lxml.etree import ElementTree
 #+---------------------------------------------------------------------------+
 #| Local application imports                                                 |
 #+---------------------------------------------------------------------------+
@@ -142,4 +143,38 @@ class ZLibEncodingFunction(EncodingFunction):
         if _compression_level < 0 or _compression_level > 9:
             raise ValueError("Compression level must be positive and inferior to 10")
         self.__compression_level = _compression_level
-        
+
+    def XMLProperties(currentFunction, xmlZLibEncodingFunction, symbol_namespace, common_namespace):
+        # Save the Properties
+        if currentFunction.compress_data is not None:
+            xmlZLibEncodingFunction.set("compress_data", str(currentFunction.compress_data))
+        if currentFunction.compression_level is not None:
+            xmlZLibEncodingFunction.set("compression_level", str(currentFunction.compression_level))
+
+    def saveToXML(self, xmlRoot, symbol_namespace, common_namespace):
+        xmlZLibEncodingFunction = etree.SubElement(xmlRoot, "{" + symbol_namespace + "}ZLibEncodingFunction")
+
+        ZLibEncodingFunction.XMLProperties(self, xmlZLibEncodingFunction, symbol_namespace, common_namespace)
+
+    @staticmethod
+    def restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes):
+
+        if xmlroot.get('compress_data') is not None:
+            attributes['compress_data'] = str(xmlroot.get('compress_data')) == 'True'
+        else:
+            attributes['compress_data'] = True
+        if xmlroot.get('compression_level') is not None:
+            attributes['compression_level'] = int(xmlroot.get('compression_level'))
+        else:
+            attributes['compression_level'] = 6
+
+    @staticmethod
+    def loadFromXML(xmlroot, symbol_namespace, common_namespace):
+
+        a = ZLibEncodingFunction.restoreFromXML(xmlroot, symbol_namespace, common_namespace, dict())
+
+        ZLibEnc = None
+
+        if 'compress_data' in a.keys() and 'compression_level' in a.keys():
+            ZLibEnc = ZLibEncodingFunction(compress_data=a['compress_data'], compression_level=a['compression_level'])
+        return ZLibEnc

--- a/netzob/src/netzob/Model/Vocabulary/Functions/VisualizationFunction.py
+++ b/netzob/src/netzob/Model/Vocabulary/Functions/VisualizationFunction.py
@@ -40,7 +40,8 @@ import uuid
 #+---------------------------------------------------------------------------+
 #| Related third party imports                                               |
 #+---------------------------------------------------------------------------+
-
+from lxml import etree
+from lxml.etree import ElementTree
 #+---------------------------------------------------------------------------+
 #| Local application imports                                                 |
 #+---------------------------------------------------------------------------+
@@ -62,3 +63,48 @@ class VisualizationFunction(object):
                        ") doesn't define 'getTags' !")
         raise NotImplementedError("The function class (" + self.getType() +
                                   ") doesn't define 'getTags' !")
+
+    def XMLProperties(currentFunction, xmlVisuFunction, symbol_namespace, common_namespace):
+        # Save the Properties
+        if currentFunction.TYPE is not None:
+            xmlVisuFunction.set("TYPE", str(currentFunction.TYPE))
+        if currentFunction.start is not None:
+            xmlVisuFunction.set("start", str(currentFunction.start))
+        if currentFunction.end is not None:
+            xmlVisuFunction.set("end", str(currentFunction.end))
+        if currentFunction.id is not None:
+            xmlVisuFunction.set("id", str(currentFunction.id.hex))
+
+    def saveToXML(self, xmlRoot, symbol_namespace, common_namespace):
+        xmlVisuFunction = etree.SubElement(xmlRoot, "{" + symbol_namespace + "}VisualizationFunction")
+
+        VisualizationFunction.XMLProperties(self, xmlVisuFunction, symbol_namespace, common_namespace)
+
+    @staticmethod
+    def restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes):
+
+        if xmlroot.get('TYPE') is not None:
+            attributes['TYPE'] = str(xmlroot.get('TYPE'))
+        if xmlroot.get('start') is not None:
+            attributes['start'] = int(xmlroot.get('start'))
+        if xmlroot.get('end') is not None:
+            attributes['end'] = int(xmlroot.get('end'))
+        if xmlroot.get('id') is not None:
+            attributes['id'] = uuid.UUID(hex=str(xmlroot.get('id')))
+        return attributes
+
+    @staticmethod
+    def loadFromXML(xmlroot, symbol_namespace, common_namespace):
+
+        a = VisualizationFunction.restoreFromXML(xmlroot, symbol_namespace, common_namespace, dict())
+
+        VisuFunc = None
+
+        if 'start' in a.keys() and 'end' in a.keys():
+            VisuFunc = VisualizationFunction(start=a['start'], end=a['end'])
+            if 'id' in a.keys():
+                VisuFunc.id = a['id']
+            # This is not possible and necessary
+            # if 'TYPE' in a.keys():
+            #     VisuFunc.TYPE = a['TYPE']
+        return VisuFunc

--- a/netzob/src/netzob/Model/Vocabulary/Functions/VisualizationFunctions/HighlightFunction.py
+++ b/netzob/src/netzob/Model/Vocabulary/Functions/VisualizationFunctions/HighlightFunction.py
@@ -38,7 +38,8 @@
 #+---------------------------------------------------------------------------+
 #| Related third party imports                                               |
 #+---------------------------------------------------------------------------+
-
+from lxml import etree
+from lxml.etree import ElementTree
 #+---------------------------------------------------------------------------+
 #| Local application imports                                                 |
 #+---------------------------------------------------------------------------+
@@ -57,3 +58,30 @@ class HighlightFunction(VisualizationFunction):
 
     def getTags(self):
         return (self.TAG_START, self.TAG_END)
+
+    def XMLProperties(currentFunction, xmlHighlightFunction, symbol_namespace, common_namespace):
+        # Save the Properties
+        VisualizationFunction.XMLProperties(currentFunction, xmlHighlightFunction, symbol_namespace, common_namespace)
+
+    def saveToXML(self, xmlRoot, symbol_namespace, common_namespace):
+        xmlHighlightFunction = etree.SubElement(xmlRoot, "{" + symbol_namespace + "}HighlightFunction")
+
+        HighlightFunction.XMLProperties(self, xmlHighlightFunction, symbol_namespace, common_namespace)
+
+    @staticmethod
+    def restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes):
+
+        VisualizationFunction.restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes)
+        return attributes
+
+    @staticmethod
+    def loadFromXML(xmlroot, symbol_namespace, common_namespace):
+        a = HighlightFunction.restoreFromXML(xmlroot, symbol_namespace, common_namespace, dict())
+
+        HighLightFunc = None
+
+        if 'start' in a.keys() and 'end' in a.keys():
+            HighLightFunc = HighlightFunction(start=a['start'], end=a['end'])
+            if 'id' in a.keys():
+                HighLightFunc.id = a['id']
+        return HighLightFunc

--- a/netzob/src/netzob/Model/Vocabulary/Messages/L4NetworkMessage.py
+++ b/netzob/src/netzob/Model/Vocabulary/Messages/L4NetworkMessage.py
@@ -32,7 +32,8 @@
 #+---------------------------------------------------------------------------+
 #| Related third party imports
 #+---------------------------------------------------------------------------+
-
+from lxml import etree
+from lxml.etree import ElementTree
 #+---------------------------------------------------------------------------+
 #| Local application imports
 #+---------------------------------------------------------------------------+
@@ -131,3 +132,78 @@ class L4NetworkMessage(L3NetworkMessage):
         """
         return "{0}:{1}".format(
             str(self.l3DestinationAddress), str(self.l4DestinationAddress))
+
+    def XMLProperties(currentMessage, xmlL4Message, symbol_namespace, common_namespace):
+        if currentMessage.l4Protocol is not None:
+            xmlL4Message.set("l4Protocol", str(currentMessage.l4Protocol))
+        if currentMessage.l4SourceAddress is not None:
+            xmlL4Message.set("l4SourceAddress", str(currentMessage.l4SourceAddress))
+        if currentMessage.l4DestinationAddress is not None:
+            xmlL4Message.set("l4DestinationAddress", str(currentMessage.l4DestinationAddress))
+
+        # Save the Properties inherited from  L3NetworkMassage
+        L3NetworkMessage.XMLProperties(currentMessage, xmlL4Message, symbol_namespace, common_namespace)
+
+
+    def saveToXML(self, xmlRoot, symbol_namespace, common_namespace):
+        xmlL4Message = etree.SubElement(xmlRoot, "{" + symbol_namespace + "}L4NetworkMessage")
+
+        L4NetworkMessage.XMLProperties(self, xmlL4Message, symbol_namespace, common_namespace)
+
+    @staticmethod
+    def restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes):
+        if xmlroot.get('l4Protocol') is not None:
+            attributes['l4Protocol'] = str(xmlroot.get('l4Protocol'))
+        else:
+            attributes['l4Protocol'] = None
+        if xmlroot.get('l4SourceAddress') is not None:
+            attributes['l4SourceAddress'] = int(xmlroot.get('l4SourceAddress'))
+        else:
+            attributes['l4SourceAddress'] = None
+        if xmlroot.get('l4DestinationAddress') is not None:
+            attributes['l4DestinationAddress'] = int(xmlroot.get('l4DestinationAddress'))
+        else:
+            attributes['l4DestinationAddress'] = None
+
+        L3NetworkMessage.restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes)
+
+        return attributes
+
+    @staticmethod
+    def loadFromXML(xmlroot, symbol_namespace, common_namespace):
+        a = L4NetworkMessage.restoreFromXML(xmlroot, symbol_namespace, common_namespace, dict())
+
+        l4msg = None
+        if 'data' in a.keys():
+            l4msg = L4NetworkMessage(data=a['data'], date=a['date'],
+                                     l2Protocol=a['l2Protocol'],
+                                     l2SourceAddress=a['l2SourceAddress'],
+                                     l2DestinationAddress=a['l2DestinationAddress'],
+                                     l3Protocol=a['l3Protocol'],
+                                     l3SourceAddress=a['l3SourceAddress'],
+                                     l3DestinationAddress=a['l3DestinationAddress'],
+                                     l4Protocol=a['l4Protocol'],
+                                     l4SourceAddress=a['l4SourceAddress'],
+                                     l4DestinationAddress=a['l4DestinationAddress'])
+
+            # This might be not correct
+            # if 'source' in a.keys():
+            #     l4msg.source = a['source']
+            # if 'destination' in a.keys():
+            #     l4msg.destination = a['destination']
+
+            if 'messageType' in a.keys():
+                l4msg.messageType = a['messageType']
+            if 'id' in a.keys():
+                l4msg.id = a['id']
+            if 'metadata' in a.keys():
+                l4msg.metadata = a['metadata']
+            if 'semanticTags' in a.keys():
+                l4msg.description = a['semanticTags']
+            if 'visualizationFunctions' in a.keys():
+                l4msg.visualizationFunctions = a['visualizationFunctions']
+            if 'session' in a.keys():
+                from netzob.Export.XMLHandler.XMLHandler import XMLHandler
+                unresolved = {a['session']: l4msg}
+                XMLHandler.add_to_unresolved_dict('session', unresolved)
+        return l4msg

--- a/netzob/src/netzob/Model/Vocabulary/Types/BitArray.py
+++ b/netzob/src/netzob/Model/Vocabulary/Types/BitArray.py
@@ -40,6 +40,8 @@ import random
 # | Related third party imports                                               |
 # +---------------------------------------------------------------------------+
 from bitarray import bitarray
+from lxml import etree
+from lxml.etree import ElementTree
 
 # +---------------------------------------------------------------------------+
 # | Local application imports                                                 |
@@ -207,3 +209,35 @@ class BitArray(AbstractType):
         b = bitarray(endian=endian)
         b.frombytes(norm_data)
         return b
+
+    def XMLProperties(currentType, xmlBitarray, symbol_namespace, common_namespace):
+        AbstractType.XMLProperties(currentType, xmlBitarray, symbol_namespace, common_namespace)
+
+    def saveToXML(self, xmlroot, symbol_namespace, common_namespace):
+        xmlBitarray = etree.SubElement(xmlroot, "{" + symbol_namespace + "}bitarray")
+
+        BitArray.XMLProperties(self, xmlBitarray, symbol_namespace, common_namespace)
+
+    @staticmethod
+    def restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes):
+
+        AbstractType.restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes)
+
+        return attributes
+
+    @staticmethod
+    def loadFromXML(xmlroot, symbol_namespace, common_namespace):
+
+        a = BitArray.restoreFromXML(xmlroot, symbol_namespace, common_namespace, dict())
+
+        bitarray = BitArray(value=a['value'], nbBits=a['size'])
+
+        if 'unitSize' in a.keys():
+            bitarray.unitSize = a['unitSize']
+        if 'endianness' in a.keys():
+            bitarray.endianness = a['endianness']
+        if 'sign' in a.keys():
+            bitarray.sign = a['sign']
+        if 'id' in a.keys():
+            bitarray.id = a['id']
+        return bitarray

--- a/netzob/src/netzob/Model/Vocabulary/Types/HexaString.py
+++ b/netzob/src/netzob/Model/Vocabulary/Types/HexaString.py
@@ -40,7 +40,8 @@ from bitarray import bitarray
 #+---------------------------------------------------------------------------+
 #| Related third party imports                                               |
 #+---------------------------------------------------------------------------+
-
+from lxml import etree
+from lxml.etree import ElementTree
 #+---------------------------------------------------------------------------+
 #| Local application imports                                                 |
 #+---------------------------------------------------------------------------+
@@ -197,3 +198,36 @@ class HexaString(AbstractType):
             raise TypeError("data cannot be None")
 
         return binascii.hexlify(data)
+
+    def XMLProperties(currentType, xmlHexaString, symbol_namespace, common_namespace):
+        AbstractType.XMLProperties(currentType, xmlHexaString, symbol_namespace, common_namespace)
+
+    def saveToXML(self, xmlroot, symbol_namespace, common_namespace):
+        xmlHexaString = etree.SubElement(xmlroot, "{" + symbol_namespace + "}hexaString")
+
+        HexaString.XMLProperties(self, xmlHexaString, symbol_namespace, common_namespace)
+
+    @staticmethod
+    def restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes):
+
+        AbstractType.restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes)
+        return attributes
+
+    @staticmethod
+    def loadFromXML(xmlroot, symbol_namespace, common_namespace):
+
+        a = HexaString.restoreFromXML(xmlroot, symbol_namespace, common_namespace, dict())
+
+        hexaString = HexaString(value=a['value'], size=a['size'])
+
+        if 'unitSize' in a.keys():
+            hexaString.unitSize = a['unitSize']
+        if 'endianness' in a.keys():
+            hexaString.endianness = a['endianness']
+        if 'sign' in a.keys():
+            hexaString.sign = a['sign']
+        if 'id' in a.keys():
+            hexaString.id = a['id']
+        return hexaString
+
+

--- a/netzob/src/netzob/Model/Vocabulary/Types/IPv4.py
+++ b/netzob/src/netzob/Model/Vocabulary/Types/IPv4.py
@@ -42,7 +42,8 @@ import random
 # +---------------------------------------------------------------------------+
 from netaddr import IPAddress, IPNetwork
 from bitarray import bitarray
-
+from lxml import etree
+from lxml.etree import ElementTree
 # +---------------------------------------------------------------------------+
 # | Local application imports                                                 |
 # +---------------------------------------------------------------------------+
@@ -354,3 +355,39 @@ class IPv4(AbstractType):
         except Exception as e:
             raise TypeError("Impossible encode {0} into an IPv4 data ({1})".
                             format(data, e))
+
+    def XMLProperties(currentType, xmlIPv4, symbol_namespace, common_namespace):
+        AbstractType.XMLProperties(currentType, xmlIPv4, symbol_namespace, common_namespace)
+
+        # Save Properties
+        if currentType.network is not None:
+            xmlIPv4.set("network", str(currentType.network))
+
+    def saveToXML(self, xmlroot, symbol_namespace, common_namespace):
+        xmlIPv4 = etree.SubElement(xmlroot, "{" + symbol_namespace + "}ipv4")
+
+        IPv4.XMLProperties(self, xmlIPv4, symbol_namespace, common_namespace)
+
+    @staticmethod
+    def restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes):
+
+        AbstractType.restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes)
+
+        if xmlroot.get('network') is not None:
+            attributes['network'] = IPNetwork(str(xmlroot.get('network')))
+        else:
+            attributes['network'] = None
+
+        return attributes
+
+    @staticmethod
+    def loadFromXML(xmlroot, symbol_namespace, common_namespace):
+
+        a = IPv4.restoreFromXML(xmlroot, symbol_namespace, common_namespace, dict())
+
+        ipv4 = IPv4(value=a['value'], unitSize=a['unitSize'], endianness=a['endianness'],
+                  sign=a['sign'], network=a['network'])
+
+        if 'id' in a.keys():
+            ipv4.id = a['id']
+        return ipv4

--- a/netzob/src/netzob/Model/Vocabulary/Types/Integer.py
+++ b/netzob/src/netzob/Model/Vocabulary/Types/Integer.py
@@ -41,7 +41,8 @@ from bitarray import bitarray
 # +---------------------------------------------------------------------------+
 # | Related third party imports                                               |
 # +---------------------------------------------------------------------------+
-
+from lxml import etree
+from lxml.etree import ElementTree
 # +---------------------------------------------------------------------------+
 # | Local application imports                                                 |
 # +---------------------------------------------------------------------------+
@@ -111,6 +112,8 @@ class Integer(AbstractType):
                 dst_unitSize=unitSize,
                 dst_endianness=endianness,
                 dst_sign=sign)
+        elif isinstance(value, bitarray):
+            pass
         else:
             value = None
 
@@ -371,3 +374,41 @@ class Integer(AbstractType):
             unitFormat = unitFormat.upper()
 
         return endianFormat + unitFormat
+
+    def XMLProperties(currentType, xmlInteger, symbol_namespace, common_namespace):
+        AbstractType.XMLProperties(currentType, xmlInteger, symbol_namespace, common_namespace)
+
+        # Save Properties
+        # if currentType.length is not None:
+        #     xmlInteger.set("length", str(currentType.length))
+
+    def saveToXML(self, xmlroot, symbol_namespace, common_namespace):
+        xmlInteger = etree.SubElement(xmlroot, "{" + symbol_namespace + "}integer")
+
+        Integer.XMLProperties(self, xmlInteger, symbol_namespace, common_namespace)
+
+    @staticmethod
+    def restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes):
+
+        AbstractType.restoreFromXML(xmlroot, symbol_namespace, common_namespace, attributes)
+
+        # if xmlroot.get('length') is not None:
+        #     attributes['length'] = int(xmlroot.get('length'))
+        # else:
+        #     attributes['length'] = None
+
+        return attributes
+
+    @staticmethod
+    def loadFromXML(xmlroot, symbol_namespace, common_namespace):
+
+        a = Integer.restoreFromXML(xmlroot, symbol_namespace, common_namespace, dict())
+
+        integer = Integer(value=a['value'], unitSize=a['unitSize'], endianness=a['endianness'], sign=a['sign'])
+        # integer = Integer(value=a['value'], length=a['length'], unitSize=a['unitSize'], endianness=a['endianness'],
+        #                   sign=a['sign'])
+
+        if 'id' in a.keys():
+            integer.id = a['id']
+        return integer
+


### PR DESCRIPTION
Offers methods for saving and loading a list of Symbols inclusivly the sessions.

This Modul saves and loads a Symbol + all included data. The approach is adapted from the XML-Modul from the Netzob release 0.4.2. For every class involved there are 4 methods:

saveToXML(): Creates a XML-Node and calls XMLProperties()
XMLProperties(): Adds the XML-Attributs to the Node.

loadFromXML(): Creates a Python Object out of the XML Node and calls RestoreFromXML()
RestoreFromXML(): Loads the attributs from the XML Node and provieds it to the loadFromXML() Method