### PR TITLE
Common(typeCheck): setup type annotations with given arguments

### DIFF
--- a/netzob/src/netzob/Common/Utils/Decorators.py
+++ b/netzob/src/netzob/Common/Utils/Decorators.py
@@ -187,6 +187,10 @@ def typeCheck(*types):
                                               ]), argument.__class__.__name__))
             return func(*args, **kwargs)
 
+        if hasattr(func, '__annotations__'):
+            for arg, typ in zip(func.__code__.co_varnames[1:], types):
+                func.__annotations__.setdefault(arg, typ)
+
         return wraps(func)(wrapped_f)
 
     return _typeCheck_


### PR DESCRIPTION
Assuming @typeCheck defines the typing of a method, it may be convenient to mark them as type annotations as defined in [PEP 526](https://www.python.org/dev/peps/pep-0526/).

This way, static type checkers could also use these hints automatically.