### PR TITLE
Use get_mac_address from getmac instead of arpreq to support OS X

### DIFF
--- a/netzob/requirements.txt
+++ b/netzob/requirements.txt
@@ -6,5 +6,5 @@ numpy
 colorama==0.3.3
 bintrees==2.0.0
 minepy==1.0.0
-arpreq==0.3.1
 pylstar==0.1.2
+getmac==0.8.2

--- a/netzob/src/netzob/Simulator/Channels/RawEthernetClient.py
+++ b/netzob/src/netzob/Simulator/Channels/RawEthernetClient.py
@@ -38,7 +38,7 @@ import socket
 from bitarray import bitarray
 import struct
 from fcntl import ioctl
-import arpreq
+from getmac import get_mac_address
 import subprocess
 import time
 import binascii
@@ -208,7 +208,7 @@ class RawEthernetClient(AbstractChannel):
         # Ethernet header
 
         # Retrieve remote MAC address
-        dstMacAddr = arpreq.arpreq(self.remoteIP)
+        dstMacAddr = get_mac_address(ip=self.remoteIP)
         if dstMacAddr is not None:
             dstMacAddr = dstMacAddr.replace(':', '')
             dstMacAddr = binascii.unhexlify(dstMacAddr)
@@ -218,7 +218,7 @@ class RawEthernetClient(AbstractChannel):
             p.wait()
             time.sleep(0.1)
 
-            dstMacAddr = arpreq.arpreq(self.remoteIP)
+            dstMacAddr = get_mac_address(ip=self.remoteIP)
             if dstMacAddr is not None:
                 dstMacAddr = dstMacAddr.replace(':', '')
                 dstMacAddr = binascii.unhexlify(dstMacAddr)


### PR DESCRIPTION
arpreq isn't supported on OS X, while get_mac_address is portable.