### PR TITLE
Bugfix on SortedTypedList.clear()

### DIFF
--- a/netzob/src/netzob/Common/Utils/SortedTypedList.py
+++ b/netzob/src/netzob/Common/Utils/SortedTypedList.py
@@ -122,6 +122,7 @@ class SortedTypedList(object):
         """remove all items from the list.
         It's a O(n) operation"""
         self.__treePriorities.clear()
+        self.__mapMessages.clear()
 
     def _extend(self, elements):
         """Add all the elements in the current list.


### PR DESCRIPTION
SortedTypedList.clear() does not fully clear the container, as a .add() call after a .clear() restores all the previous content.
Troubleshoot code sample: 
```
from netzob.Common.Utils.SortedTypedList import SortedTypedList
from netzob.Model.Vocabulary.Functions.EncodingFunctions.TypeEncodingFunction import TypeEncodingFunction
from netzob.Model.Vocabulary.Types.Integer import Integer

lst = SortedTypedList(TypeEncodingFunction)
print(lst)

for i in range(3):
    lst.clear()
    lst.add(TypeEncodingFunction(Integer))
    print(i)
    print(lst)
```